### PR TITLE
Change test harnesses so the setup they provide can be used for every test method and some other test cleanup.

### DIFF
--- a/src/main/scala/com/linkedin/kafka/clients/utils/tests/AbstractKafkaClientsIntegrationTestHarness.scala
+++ b/src/main/scala/com/linkedin/kafka/clients/utils/tests/AbstractKafkaClientsIntegrationTestHarness.scala
@@ -60,6 +60,9 @@ abstract class AbstractKafkaClientsIntegrationTestHarness extends AbstractKafkaI
     new LiKafkaConsumerImpl(consumerProps)
   }
 
+  /**
+    * Sets a value if props does not already have the key.
+    */
   def maybeSetProperties(props: Properties, key: String, value: String) {
     if (!props.containsKey(key))
       props.setProperty(key, value);

--- a/src/main/scala/com/linkedin/kafka/clients/utils/tests/AbstractKafkaServerTestHarness.scala
+++ b/src/main/scala/com/linkedin/kafka/clients/utils/tests/AbstractKafkaServerTestHarness.scala
@@ -42,12 +42,6 @@ abstract class AbstractKafkaServerTestHarness extends AbstractZookeeperTestHarne
    */
   def generateConfigs(): Seq[KafkaConfig]
 
-  def configs: Seq[KafkaConfig] = {
-    if (instanceConfigs == null)
-      instanceConfigs = generateConfigs()
-    instanceConfigs
-  }
-
   def serverForId(id: Int) = servers.find(s => s.config.brokerId == id)
 
   def bootstrapUrl: String = brokerList
@@ -61,6 +55,7 @@ abstract class AbstractKafkaServerTestHarness extends AbstractZookeeperTestHarne
   @Before
   override def setUp() {
     super.setUp()
+    val configs = generateConfigs()
     if (configs.size <= 0)
       throw new KafkaException("Must supply at least one server config.")
     servers = configs.map(TestUtils.createServer(_)).toBuffer


### PR DESCRIPTION
Test harnesses no longer cache the address of the zookeeper server.
Use @BeforeMethod rather than @BeforeTest which seems to be a legacy left over from bad old days of XML configuration files,
this also causes the @BeforeTest methods to be run once per test.
Initialize the consumer integration tests before each test.
Seed the random number generator with a known constant so tests are repeatable.
