### PR TITLE
Build test jar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,6 @@ sourceSets {
 }
 
 dependencies {
-
     compile 'org.apache.kafka:kafka-clients:0.10.1.1'
 
     testCompile 'org.apache.kafka:kafka_2.10:0.10.1.1:test'
@@ -44,6 +43,21 @@ test {
         events "passed", "failed", "skipped"
     }
 }
+
+configurations {
+    testArtifacts.extendsFrom testRuntime
+}
+
+task testJar(type: Jar) {
+    classifier = 'tests'
+    from sourceSets.test.output
+}
+
+artifacts {
+    testArtifacts testJar
+}
+
+build.dependsOn 'testJar'
 
 task wrapper(type: Wrapper) {
     gradleVersion = '2.13' //version required


### PR DESCRIPTION
Huge thanks to Radai for https://github.com/linkedin/li-apache-kafka-clients/pull/21, which keeps the test harnesses out of the main artifact.

We'll need the test harnesses to be published to an artifact as there are currently tests in other libraries depending on the test harnesses