### PR TITLE
drop scala daemon, disable kafka test broker log compaction to save memory

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,6 +64,7 @@ dependencies {
 
 test {
     useTestNG {}
+    maxHeapSize = "1024m"
     testLogging {
         events "passed", "failed", "skipped"
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,4 @@
 version=0.0.5-SNAPSHOT
+org.gradle.daemon=false
+org.gradle.parallel=false
+org.gradle.jvmargs=-Xms512m -Xmx512m

--- a/src/test/scala/com/linkedin/kafka/clients/utils/tests/TestUtils.scala
+++ b/src/test/scala/com/linkedin/kafka/clients/utils/tests/TestUtils.scala
@@ -119,7 +119,8 @@ object TestUtils {
                          enablePlaintext: Boolean = true,
                          enableSaslPlaintext: Boolean = false, saslPlaintextPort: Int = RandomPort,
                          enableSsl: Boolean = false, sslPort: Int = RandomPort,
-                         enableSaslSsl: Boolean = false, saslSslPort: Int = RandomPort, rack: Option[String] = None)
+                         enableSaslSsl: Boolean = false, saslSslPort: Int = RandomPort, rack: Option[String] = None,
+                         enableLogCleaner: Boolean = false)
   : Properties = {
 
     def shouldEnable(protocol: SecurityProtocol) = interBrokerSecurityProtocol.fold(false)(_ == protocol)
@@ -149,6 +150,7 @@ object TestUtils {
     props.put("delete.topic.enable", enableDeleteTopic.toString)
     props.put("controlled.shutdown.retry.backoff.ms", "100")
     props.put("log.cleaner.dedupe.buffer.size", "2097152")
+    props.put("log.cleaner.enable", enableLogCleaner.toString)
     rack.foreach(props.put("broker.rack", _))
 
     if (protocolAndPorts.exists { case (protocol, _) => usesSslTransportLayer(protocol)})


### PR DESCRIPTION
for great justice

Signed-off-by: rrosenbl <rrosenblatt@linkedin.com>