### PR TITLE
Add sanity check logic to the message eviction.

### DIFF
--- a/src/main/java/com/linkedin/kafka/clients/largemessage/LargeMessageBufferPool.java
+++ b/src/main/java/com/linkedin/kafka/clients/largemessage/LargeMessageBufferPool.java
@@ -102,6 +102,7 @@ public class LargeMessageBufferPool {
 
   public synchronized void clear() {
     _incompleteMessageMap.clear();
+    _incompleteMessageByPartition.clear();
     _offsetTracker.clear();
     _bufferUsed = 0L;
   }
@@ -205,7 +206,7 @@ public class LargeMessageBufferPool {
   }
 
 
-  // Adding the sanity check to see if
+  // Adding the sanity check to see if the buffered messages match the buffer used.
   private void sanityCheck() {
     int bufferedBytes = 0;
     for (Set<UUID> uuids : _incompleteMessageByPartition.values()) {

--- a/src/main/java/com/linkedin/kafka/clients/utils/QueuedMap.java
+++ b/src/main/java/com/linkedin/kafka/clients/utils/QueuedMap.java
@@ -132,6 +132,7 @@ public class QueuedMap<K, V> {
         node.next = null;
         _tail = node;
       }
+      _size++;
     }
 
     public synchronized ListNode addKey(K key) {

--- a/src/test/java/com/linkedin/kafka/clients/consumer/LiKafkaConsumerIntegrationTest.java
+++ b/src/test/java/com/linkedin/kafka/clients/consumer/LiKafkaConsumerIntegrationTest.java
@@ -783,7 +783,6 @@ public class LiKafkaConsumerIntegrationTest extends AbstractKafkaClientsIntegrat
       ConsumerRecords<byte[], byte[]> records = ConsumerRecords.empty();
       while (records.isEmpty()) {
         records = consumer.poll(1000);
-        System.out.println(records.count() + ", " + records.isEmpty());
       }
       assertEquals(records.count(), 1, "Only the first message should be returned");
       assertEquals(records.iterator().next().offset(), 2L, "The offset of the first message should be 2.");
@@ -1033,8 +1032,8 @@ public class LiKafkaConsumerIntegrationTest extends AbstractKafkaClientsIntegrat
 
 
     // Add two more segment to partition SYNTHETIC_PARTITION_1 for corner case test.
-    List<ProducerRecord<byte[], byte[]>> m0SegsPartition1 = splitter.split(topic, SYNTHETIC_PARTITION_1, messageId0, message0.getBytes());
-    List<ProducerRecord<byte[], byte[]>> m1SegsPartition1 = splitter.split(topic, SYNTHETIC_PARTITION_1, messageId1, message1.getBytes());
+    List<ProducerRecord<byte[], byte[]>> m0SegsPartition1 = splitter.split(topic, SYNTHETIC_PARTITION_1, LiKafkaClientsUtils.randomUUID(), message0.getBytes());
+    List<ProducerRecord<byte[], byte[]>> m1SegsPartition1 = splitter.split(topic, SYNTHETIC_PARTITION_1, LiKafkaClientsUtils.randomUUID(), message1.getBytes());
 
     try {
       producer.send(m0Segs.get(0)).get();


### PR DESCRIPTION
We saw a case that the used buffer recorded by LargeMessageBufferPool was none zero while there was no large message buffered. Adding the sanity check logic and hopefully we can catch the issue.