### PR TITLE
Add SSL support to integration tests

### DIFF
--- a/src/test/java/com/linkedin/kafka/clients/consumer/LiKafkaConsumerIntegrationTest.java
+++ b/src/test/java/com/linkedin/kafka/clients/consumer/LiKafkaConsumerIntegrationTest.java
@@ -56,8 +56,10 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import static org.testng.Assert.*;
-
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.fail;
 
 /**
  * Integration test for LiKafkaConsumer

--- a/src/test/java/com/linkedin/kafka/clients/consumer/LiKafkaConsumerIntegrationTest.java
+++ b/src/test/java/com/linkedin/kafka/clients/consumer/LiKafkaConsumerIntegrationTest.java
@@ -15,10 +15,22 @@ import com.linkedin.kafka.clients.producer.UUIDFactory;
 import com.linkedin.kafka.clients.utils.LiKafkaClientsTestUtils;
 import com.linkedin.kafka.clients.utils.LiKafkaClientsUtils;
 import com.linkedin.kafka.clients.utils.tests.AbstractKafkaClientsIntegrationTestHarness;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Random;
+import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ConcurrentSkipListMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 import kafka.server.KafkaConfig;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
@@ -32,7 +44,6 @@ import org.apache.kafka.clients.consumer.OffsetCommitCallback;
 import org.apache.kafka.clients.consumer.OffsetOutOfRangeException;
 import org.apache.kafka.clients.consumer.OffsetResetStrategy;
 import org.apache.kafka.clients.producer.Callback;
-import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
@@ -40,29 +51,12 @@ import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.SerializationException;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
-import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
-import java.util.Random;
-import java.util.Set;
-import java.util.UUID;
-import java.util.concurrent.atomic.AtomicBoolean;
-
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertNull;
-import static org.testng.Assert.fail;
+import static org.testng.Assert.*;
 
 
 /**
@@ -1001,9 +995,7 @@ public class LiKafkaConsumerIntegrationTest extends AbstractKafkaClientsIntegrat
                                                        new DefaultSegmentSerializer(),
                                                        new UUIDFactory.DefaultUUIDFactory<>());
 
-    Properties props = new Properties();
-    props.setProperty(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers());
-    Producer<byte[], byte[]> producer = new KafkaProducer<>(props, new ByteArraySerializer(), new ByteArraySerializer());
+    Producer<byte[], byte[]> producer = createKafkaProducer();
     // Prepare messages.
     int messageSize = MAX_SEGMENT_SIZE + MAX_SEGMENT_SIZE / 2;
     // M0, 2 segments

--- a/src/test/java/com/linkedin/kafka/clients/consumer/LiKafkaConsumerSSLIntegrationTest.java
+++ b/src/test/java/com/linkedin/kafka/clients/consumer/LiKafkaConsumerSSLIntegrationTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License").  See License in the project root for license information.
+ */
+
+package com.linkedin.kafka.clients.consumer;
+
+import java.io.File;
+import java.io.IOException;
+import org.apache.kafka.common.protocol.SecurityProtocol;
+import org.testng.Assert;
+import scala.Option;
+
+public class LiKafkaConsumerSSLIntegrationTest extends LiKafkaConsumerIntegrationTest {
+
+  private File _trustStoreFile;
+
+  public LiKafkaConsumerSSLIntegrationTest() {
+    super();
+    try {
+      _trustStoreFile = File.createTempFile("truststore", ".jks");
+    } catch (IOException e) {
+      Assert.fail("Failed to create trust store");
+    }
+  }
+
+  @Override
+  public Option<File> trustStoreFile() {
+    return Option.apply(_trustStoreFile);
+  }
+
+  @Override
+  public SecurityProtocol securityProtocol() {
+    return SecurityProtocol.SSL;
+  }
+}

--- a/src/test/java/com/linkedin/kafka/clients/producer/LiKafkaProducerIntegrationTest.java
+++ b/src/test/java/com/linkedin/kafka/clients/producer/LiKafkaProducerIntegrationTest.java
@@ -7,7 +7,12 @@ package com.linkedin.kafka.clients.producer;
 import com.linkedin.kafka.clients.consumer.LiKafkaConsumer;
 import com.linkedin.kafka.clients.largemessage.errors.SkippableException;
 import com.linkedin.kafka.clients.utils.tests.AbstractKafkaClientsIntegrationTestHarness;
+import java.io.IOException;
+import java.util.BitSet;
+import java.util.Collections;
 import java.util.Map;
+import java.util.Properties;
+import java.util.Random;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
@@ -18,12 +23,6 @@ import org.apache.kafka.common.serialization.StringSerializer;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
-
-import java.io.IOException;
-import java.util.BitSet;
-import java.util.Collections;
-import java.util.Properties;
-import java.util.Random;
 
 import static org.testng.AssertJUnit.*;
 

--- a/src/test/java/com/linkedin/kafka/clients/producer/LiKafkaProducerSSLIntegrationTest.java
+++ b/src/test/java/com/linkedin/kafka/clients/producer/LiKafkaProducerSSLIntegrationTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2017 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License").  See License in the project root for license information.
+ */
+
+package com.linkedin.kafka.clients.producer;
+
+import java.io.File;
+import java.io.IOException;
+import org.apache.kafka.common.protocol.SecurityProtocol;
+import org.testng.Assert;
+import scala.Option;
+
+
+public class LiKafkaProducerSSLIntegrationTest extends LiKafkaProducerIntegrationTest {
+
+  private File _trustStoreFile;
+
+  public LiKafkaProducerSSLIntegrationTest() {
+    super();
+    try {
+      _trustStoreFile = File.createTempFile("truststore", ".jks");
+    } catch (IOException e) {
+      Assert.fail("Failed to create trust store");
+    }
+  }
+
+  @Override
+  public Option<File> trustStoreFile() {
+    return Option.apply(_trustStoreFile);
+  }
+
+  @Override
+  public SecurityProtocol securityProtocol() {
+    return SecurityProtocol.SSL;
+  }
+
+}

--- a/src/test/scala/com/linkedin/kafka/clients/utils/tests/AbstractKafkaIntegrationTestHarness.scala
+++ b/src/test/scala/com/linkedin/kafka/clients/utils/tests/AbstractKafkaIntegrationTestHarness.scala
@@ -16,7 +16,15 @@ import kafka.server.KafkaConfig
 abstract class AbstractKafkaIntegrationTestHarness extends AbstractKafkaServerTestHarness {
 
   def generateConfigs() =
-    TestUtils.createBrokerConfigs(clusterSize(), zkConnect, enableControlledShutdown = false).map(KafkaConfig.fromProps(_, overridingProps()))
+    TestUtils.createBrokerConfigs(
+      clusterSize(),
+      zkConnect,
+      enableControlledShutdown = false,
+      interBrokerSecurityProtocol = Some(securityProtocol),
+      trustStoreFile = trustStoreFile,
+      enablePlaintext = trustStoreFile.isEmpty, /* enable one port or the other */
+      enableSsl = trustStoreFile.isDefined
+    ).map(KafkaConfig.fromProps(_, overridingProps()))
 
   /**
    * User can override this method to return the number of brokers they want.


### PR DESCRIPTION
We currently do not have any SSL testing in the integration test harness. This patch rectifies this gap.