### PR TITLE
Fix IndexOutputOfBoundsException when sending records with zero length values.

### DIFF
--- a/src/main/java/com/linkedin/kafka/clients/largemessage/MessageSplitterImpl.java
+++ b/src/main/java/com/linkedin/kafka/clients/largemessage/MessageSplitterImpl.java
@@ -67,10 +67,10 @@ public class MessageSplitterImpl implements MessageSplitter {
                                                     byte[] serializedRecord,
                                                     int maxSegmentSize) {
     if (topic == null) {
-      throw new IllegalArgumentException("Topic cannot be empty for LiKafkaGenericMessageSplitter.");
+      throw new IllegalArgumentException("Topic cannot be empty.");
     }
-    if (serializedRecord == null) {
-      return Collections.singletonList(new ProducerRecord<>(topic, partition, timestamp, key, null));
+    if (serializedRecord == null || serializedRecord.length == 0) {
+      return Collections.singletonList(new ProducerRecord<>(topic, partition, timestamp, key, serializedRecord));
     }
     // We allow message id to be null, but it is strongly recommended to pass in a message id.
     UUID segmentMessageId = messageId == null ? _uuidFactory.createUuid() : messageId;


### PR DESCRIPTION
The MessageSplitterImpl computes the number of segments as zero and then returns an empty list of segments.  This change causes the zero length value to be handled the same was a null value.  A producer unit test has been added for this corner case.