### PR TITLE
Always make progress on commits.

### DIFF
--- a/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/largemessage/ConsumerRecordsProcessor.java
+++ b/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/largemessage/ConsumerRecordsProcessor.java
@@ -175,7 +175,9 @@ public class ConsumerRecordsProcessor<K, V> {
         if (previousDeliveredOffset != null) {
           safeOffsetToCommit = _deliveredMessageOffsetTracker.safeOffset(tp, previousDeliveredOffset);
         } else {
-          safeOffsetToCommit = earliestTrackedOffset;
+          //In this case nothing has been delivered to the consumer (this this partition) either because we never
+          // reached the highwatermark or because we were waiting to assemble some message
+          safeOffsetToCommit = _deliveredMessageOffsetTracker.safeOffset(tp);
         }
       }
       // We need to combine the metadata with the high watermark. High watermark should never rewind.


### PR DESCRIPTION
When the highwatermark is still higher than the committed offset we still want to commit an offset that is higher than the first offset we started to consume at.

A unit test for this has been added.