### PR TITLE
Fix the calculation of remaining waiting time when closing producer

### DIFF
--- a/integration-tests/src/test/java/com/linkedin/kafka/clients/auditing/ConfigureAuditorTest.java
+++ b/integration-tests/src/test/java/com/linkedin/kafka/clients/auditing/ConfigureAuditorTest.java
@@ -10,6 +10,7 @@ import com.linkedin.kafka.clients.producer.LiKafkaProducer;
 import com.linkedin.kafka.clients.producer.LiKafkaProducerConfig;
 import com.linkedin.kafka.clients.producer.LiKafkaProducerImpl;
 import com.linkedin.kafka.clients.utils.tests.AbstractKafkaClientsIntegrationTestHarness;
+import java.util.concurrent.TimeUnit;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -69,5 +70,11 @@ public class ConfigureAuditorTest extends AbstractKafkaClientsIntegrationTestHar
     public void close() {
       configureMethodInvocations.set(0);
     }
+
+    @Override
+    public void close(long timeout, TimeUnit unit) {
+      configureMethodInvocations.set(0);
+    }
+
   }
 }

--- a/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/producer/LiKafkaProducerImpl.java
+++ b/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/producer/LiKafkaProducerImpl.java
@@ -313,13 +313,15 @@ public class LiKafkaProducerImpl<K, V> implements LiKafkaProducer<K, V> {
 
     _closed = true;
     synchronized (_numThreadsInSend) {
-      while (_numThreadsInSend.get() > 0 && System.currentTimeMillis() < deadlineTimeMs) {
+      long remainingMs = deadlineTimeMs - System.currentTimeMillis();
+      while (_numThreadsInSend.get() > 0 && remainingMs > 0) {
         try {
-          _numThreadsInSend.wait(Math.max(0, deadlineTimeMs - System.currentTimeMillis()));
+          _numThreadsInSend.wait(remainingMs);
         } catch (InterruptedException e) {
           LOG.error("Interrupted when there are still {} sender threads.", _numThreadsInSend.get());
           break;
         }
+        remainingMs = deadlineTimeMs - System.currentTimeMillis();
       }
     }
 

--- a/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/producer/LiKafkaProducerImpl.java
+++ b/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/producer/LiKafkaProducerImpl.java
@@ -296,32 +296,29 @@ public class LiKafkaProducerImpl<K, V> implements LiKafkaProducer<K, V> {
 
   @Override
   public void close() {
-    LOG.info("Shutting down ...");
-    long start = System.currentTimeMillis();
-    prepClose();
-    _auditor.close();
-    _producer.close();
-    LOG.info("Shutdown complete in {} millis", (System.currentTimeMillis() - start));
+    close(Integer.MAX_VALUE, TimeUnit.MILLISECONDS);
   }
 
   @Override
   public void close(long timeout, TimeUnit timeUnit) {
-    LOG.info("Shutting down in {} {}...", timeout, timeUnit);
-    long start = System.currentTimeMillis();
-    long budget = timeUnit.toMillis(timeout);
-    long deadline = start + budget;
-    _auditor.close(budget, TimeUnit.MILLISECONDS);
-    long remaining = System.currentTimeMillis() - deadline; //could be negative
-    _producer.close(Math.max(0, remaining), TimeUnit.MILLISECONDS);
-    LOG.info("Shutdown complete in {} millis", (System.currentTimeMillis() - start));
-  }
+    LOG.info("Shutting down LiKafkaProducer in {} {}...", timeout, timeUnit);
+    long startTimeMs = System.currentTimeMillis();
+    long budgetMs = timeUnit.toMillis(timeout);
+    long deadlineTimeMs = startTimeMs + budgetMs;
 
-  private void prepClose() {
     _closed = true;
-    // We flush first to avoid the tight loop when buffer is full.
-    _producer.flush();
-    while (_numThreadsInSend.get() > 0) { }
-    _producer.flush();
+    while (_numThreadsInSend.get() > 0 && System.currentTimeMillis() < deadlineTimeMs) {
+      try {
+        Thread.sleep(1);
+      } catch (InterruptedException e) {
+        LOG.error("Interrupted when there are still {} sender threads.", _numThreadsInSend.get());
+        break;
+      }
+    }
+
+    _auditor.close(Math.max(0, deadlineTimeMs - System.currentTimeMillis()), TimeUnit.MILLISECONDS);
+    _producer.close(Math.max(0, deadlineTimeMs - System.currentTimeMillis()), TimeUnit.MILLISECONDS);
+    LOG.info("LiKafkaProducer shutdown complete in {} millis", (System.currentTimeMillis() - startTimeMs));
   }
 
   private static class ErrorLoggingCallback<K, V> implements Callback {


### PR DESCRIPTION
This patch fixes the following issues:

- Close() with timeout didn't calculate remaining time ms correctly.
- Close() with timeout should set isClosed to true.
- Close() should have the same behavior as close(MAX_LONG).