### PR TITLE
Porting all fixes from linkinedin. 

### DIFF
--- a/integration-tests/src/test/java/com/linkedin/kafka/clients/utils/LiKafkaClientsTestUtils.java
+++ b/integration-tests/src/test/java/com/linkedin/kafka/clients/utils/LiKafkaClientsTestUtils.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2017 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License").  See License in the project root for license information.
+ */
+
+package com.linkedin.kafka.clients.utils;
+
+import com.linkedin.kafka.clients.largemessage.LargeMessageSegment;
+
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.Random;
+import java.util.UUID;
+
+import static org.testng.Assert.assertEquals;
+
+/**
+ * The util class for unit test.
+ */
+public class LiKafkaClientsTestUtils {
+
+  private LiKafkaClientsTestUtils() {
+  }
+
+  public static LargeMessageSegment createLargeMessageSegment(UUID messageId,
+      int seq,
+      int numberOfSegments,
+      int messageSizeInBytes,
+      int segmentSize) {
+    byte[] bytes = new byte[segmentSize];
+    Arrays.fill(bytes, (byte) seq);
+    return new LargeMessageSegment(messageId, seq, numberOfSegments, messageSizeInBytes, ByteBuffer.wrap(bytes));
+  }
+
+  public static void verifyMessage(byte[] serializedMessage, int messageSizeInBytes, int segmentSize) {
+    int i = 0;
+    for (; i < messageSizeInBytes / segmentSize; i++) {
+      for (int j = 0; j < segmentSize; j++) {
+        assertEquals(serializedMessage[i * segmentSize + j], (byte) i, "Byte value should match seq.");
+      }
+    }
+    for (int j = 0; j < messageSizeInBytes % segmentSize; j++) {
+      assertEquals(serializedMessage[i * segmentSize + j], (byte) i, "Byte value should match seq.");
+    }
+  }
+
+  public static String getRandomString(int length) {
+    char[] chars = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'};
+    Random random = new Random();
+    StringBuilder stringBuiler = new StringBuilder();
+    for (int i = 0; i < length; i++) {
+      stringBuiler.append(chars[Math.abs(random.nextInt()) % 16]);
+    }
+    return stringBuiler.toString();
+  }
+}

--- a/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/consumer/LiKafkaConsumerImpl.java
+++ b/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/consumer/LiKafkaConsumerImpl.java
@@ -4,18 +4,27 @@
 
 package com.linkedin.kafka.clients.consumer;
 
+import com.linkedin.kafka.clients.auditing.Auditor;
 import com.linkedin.kafka.clients.largemessage.ConsumerRecordsProcessResult;
 import com.linkedin.kafka.clients.largemessage.ConsumerRecordsProcessor;
 import com.linkedin.kafka.clients.largemessage.DeliveredMessageOffsetTracker;
 import com.linkedin.kafka.clients.largemessage.LargeMessageSegment;
 import com.linkedin.kafka.clients.largemessage.MessageAssembler;
 import com.linkedin.kafka.clients.largemessage.MessageAssemblerImpl;
-import com.linkedin.kafka.clients.auditing.Auditor;
 import com.linkedin.kafka.clients.largemessage.errors.ConsumerRecordsProcessingException;
 import com.linkedin.kafka.clients.utils.LiKafkaClientsUtils;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Locale;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
@@ -27,7 +36,6 @@ import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.consumer.OffsetAndTimestamp;
 import org.apache.kafka.clients.consumer.OffsetCommitCallback;
 import org.apache.kafka.clients.consumer.OffsetOutOfRangeException;
-import org.apache.kafka.clients.consumer.OffsetResetStrategy;
 import org.apache.kafka.clients.consumer.internals.NoOpConsumerRebalanceListener;
 import org.apache.kafka.common.Metric;
 import org.apache.kafka.common.MetricName;
@@ -37,16 +45,6 @@ import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
-import java.util.Set;
-import java.util.regex.Pattern;
 
 /**
  * The implementation of {@link LiKafkaConsumer}
@@ -76,7 +74,7 @@ public class LiKafkaConsumerImpl<K, V> implements LiKafkaConsumer<K, V> {
   private final LiKafkaOffsetCommitCallback _offsetCommitCallback;
   private final boolean _autoCommitEnabled;
   private final long _autoCommitInterval;
-  private final OffsetResetStrategy _offsetResetStrategy;
+  private final LiOffsetResetStrategy _offsetResetStrategy;
   private long _lastAutoCommitMs;
   private ConsumerRecordsProcessResult<K, V> _lastProcessedResult;
 
@@ -114,7 +112,7 @@ public class LiKafkaConsumerImpl<K, V> implements LiKafkaConsumer<K, V> {
     _autoCommitEnabled = configs.getBoolean(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG);
     _autoCommitInterval = configs.getInt(ConsumerConfig.AUTO_COMMIT_INTERVAL_MS_CONFIG);
     _offsetResetStrategy =
-        OffsetResetStrategy.valueOf(configs.getString(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG).toUpperCase(Locale.ROOT));
+        LiOffsetResetStrategy.valueOf(configs.getString(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG).toUpperCase(Locale.ROOT));
     _lastAutoCommitMs = System.currentTimeMillis();
     // We need to set the auto commit to false in KafkaConsumer because it is not large message aware.
     ByteArrayDeserializer byteArrayDeserializer = new ByteArrayDeserializer();
@@ -158,7 +156,9 @@ public class LiKafkaConsumerImpl<K, V> implements LiKafkaConsumer<K, V> {
     vDeserializer.configure(configs.originals(), false);
 
     // Instantiate consumer record processor
-    _consumerRecordsProcessor = new ConsumerRecordsProcessor<>(assembler, kDeserializer, vDeserializer, messageOffsetTracker, auditor);
+
+    _consumerRecordsProcessor = new ConsumerRecordsProcessor<>(assembler, kDeserializer, vDeserializer,
+        messageOffsetTracker, auditor, _kafkaConsumer::committed);
 
     // Instantiate consumer rebalance listener
     _consumerRebalanceListener = new LiKafkaConsumerRebalanceListener<>(_consumerRecordsProcessor,
@@ -250,19 +250,7 @@ public class LiKafkaConsumerImpl<K, V> implements LiKafkaConsumer<K, V> {
       } catch (OffsetOutOfRangeException | NoOffsetForPartitionException oe) {
         handleInvalidOffsetException(oe);
       }
-      // Check if we have enough high watermark for a partition. The high watermark is cleared during rebalance.
-      // We make this check so that after rebalance we do not deliver duplicate messages to the user.
-      if (!rawRecords.isEmpty() && _consumerRecordsProcessor.numConsumerHighWaterMarks() < assignment().size()) {
-        for (TopicPartition tp : rawRecords.partitions()) {
-          if (_consumerRecordsProcessor.consumerHighWaterMarkForPartition(tp) == null) {
-            OffsetAndMetadata offsetAndMetadata = committed(tp);
-            if (offsetAndMetadata != null) {
-              long hw = offsetAndMetadata.offset();
-              _consumerRecordsProcessor.setPartitionConsumerHighWaterMark(tp, hw);
-            }
-          }
-        }
-      }
+
       _lastProcessedResult = _consumerRecordsProcessor.process(rawRecords);
       processedRecords = _lastProcessedResult.consumerRecords();
       // Clear the internal reference.
@@ -314,7 +302,8 @@ public class LiKafkaConsumerImpl<K, V> implements LiKafkaConsumer<K, V> {
                              boolean ignoreConsumerHighWatermark,
                              OffsetCommitCallback callback,
                              boolean sync) {
-    Map<TopicPartition, OffsetAndMetadata> offsetsToCommit = getOffsetsToCommit(offsets, ignoreConsumerHighWatermark);
+    Map<TopicPartition, OffsetAndMetadata> offsetsToCommit =
+        _consumerRecordsProcessor.safeOffsetsToCommit(offsets, ignoreConsumerHighWatermark);
     if (sync) {
       LOG.trace("Committing offsets synchronously: {}", offsetsToCommit);
       _kafkaConsumer.commitSync(offsetsToCommit);
@@ -444,9 +433,97 @@ public class LiKafkaConsumerImpl<K, V> implements LiKafkaConsumer<K, V> {
         LOG.warn("Invalid positions of {} due to {}. Resetting position to the latest.", oe.partitions(), oe.getClass().getSimpleName());
         seekToEnd(oe.partitions());
         break;
+      case LICLOSEST:
+        LOG.warn("Invalid positions of {} due to {}. Resetting position to the li_closest.", oe.partitions(),
+            oe.getClass().getSimpleName());
+        handleLiClosestResetStrategy(oe);
+        break;
       default:
         throw oe;
     }
+  }
+
+  /**
+   * This method handles the OffsetResetStrategy="LICLOSEST" offset reset strategy.
+   *
+   * The semantics of this strategy is defined as follows:
+   * Consumer will {@link #seekToBeginning(Collection)} when InvalidOffsetException occurs due to:
+   * 1. New Consumer / Expired Commit Offset
+   * 2. Fall-off Start (fetch offset < LSO)
+   *
+   * Consumer will {@link #seekToEnd(Collection)} when InvalidOffsetException occurs due to:
+   * 3a. Fall-off End (fetch offset > LEO): Consumer will seek to the end
+   * 3b. Fall-off End (fetch offset <= LEO): Consumer will seek to the fetched offset
+   *
+   * Note: Offset to which we reset may not necessarily be a safe offset. This method invokes 2 blocking calls and does
+   * ignore large-message tracking metadata. If we are unable to calculate the bounds, it will throw an
+   * IllegalStateException.
+   *
+   * Design details can be found here - https://docs.google.com/document/d/1zKGXxZiyiRkLJ_d0FCoGALfAo0N7k3hh9NFYhJrbPsw/edit#
+   * @param oe InvalidOffsetException
+   */
+  private void handleLiClosestResetStrategy(InvalidOffsetException oe) {
+    if (oe instanceof NoOffsetForPartitionException) {  // Case 1
+      LOG.info("No valid offsets found. Rewinding to the earliest");
+      seekToBeginning(oe.partitions());
+    } else if (oe instanceof OffsetOutOfRangeException) {
+      Map<TopicPartition, Long> seekBeginningPartitions = new HashMap<>();
+      Map<TopicPartition, Long> seekEndPartitions = new HashMap<>();
+      Map<TopicPartition, Long> seekFetchedOffsetPartitions = new HashMap<>();
+      Set<TopicPartition> boundsUnknownPartitions = new HashSet<>();
+
+      Map<TopicPartition, Long> beginningOffsets = beginningOffsets(oe.partitions());
+      Map<TopicPartition, Long> endOffsets = endOffsets(oe.partitions());
+
+      ((OffsetOutOfRangeException) oe).offsetOutOfRangePartitions().forEach((tp, fetchedOffset) -> {
+        long beginningOffset = beginningOffsets.getOrDefault(tp, -1L);
+        long endOffset = endOffsets.getOrDefault(tp, -1L);
+        if (beginningOffset != -1L && endOffset != -1L) {
+          if (beginningOffset > fetchedOffset) {  // Case 2
+            seekBeginningPartitions.put(tp, beginningOffset);
+            return;
+          }
+          if (endOffset < fetchedOffset) {  // Case 3a
+            LOG.debug("Closest offset computed for topic partition {} is the log end offset {}. ", tp, fetchedOffset);
+            seekEndPartitions.put(tp, endOffset);
+          } else {  // Case 3b: endOffset >= fetchedOffset
+            LOG.debug("Closest offset computed for topic partition {} is the fetched offset {}. ", tp, fetchedOffset);
+            seekFetchedOffsetPartitions.put(tp, fetchedOffset);
+          }
+        } else {
+          // can't handle reset if the either bound values are not known
+          // ideally, this should never happen since the listoffsets protocol always returns all requested offset or none
+          boundsUnknownPartitions.add(tp);
+        }
+      });
+
+      if (!boundsUnknownPartitions.isEmpty()) {
+        throw new IllegalStateException("Couldn't figure out the closest offset for these topic partitions " +
+            boundsUnknownPartitions + "Aborting..");
+      }
+
+      if (!seekBeginningPartitions.isEmpty()) {
+        LOG.info("Offsets are out of range for partitions {}. Seeking to the beginning offsets returned", seekBeginningPartitions);
+        seekBeginningPartitions.forEach(this::seekAndClear);
+      }
+      if (!seekEndPartitions.isEmpty()) {
+        LOG.info("Offsets are out of range for partitions {}. Seeking to the end offsets returned", seekEndPartitions);
+        seekEndPartitions.forEach(this::seekAndClear);
+      }
+      if (!seekFetchedOffsetPartitions.isEmpty()) {
+        LOG.info("Seeking to fetched offsets for topic partitions {}. This may indicate a potential loss of data.",
+            seekFetchedOffsetPartitions.keySet());
+        seekFetchedOffsetPartitions.forEach(this::seekAndClear);
+      }
+    } else {
+      throw oe;
+    }
+  }
+
+  private void seekAndClear(TopicPartition tp, Long offset) {
+    _kafkaConsumer.seek(tp, offset);
+    _consumerRecordsProcessor.clear(tp);
+    _consumerRecordsProcessor.setPartitionConsumerHighWaterMark(tp, offset >= 1 ? offset - 1 : 0);
   }
 
   @Override
@@ -576,33 +653,6 @@ public class LiKafkaConsumerImpl<K, V> implements LiKafkaConsumer<K, V> {
     _kafkaConsumer.wakeup();
   }
 
-  /**
-   * Helper function to get the large message aware TopicPartition to OffsetAndMetadata mapping.
-   *
-   * @param offsets The user provided TopicPartition to OffsetsAndMetadata mapping.
-   * @return The translated large message aware TopicPartition to OffsetAndMetadata mapping.
-   */
-  private Map<TopicPartition, OffsetAndMetadata> getOffsetsToCommit(Map<TopicPartition, OffsetAndMetadata> offsets,
-                                                                    boolean ignoreHighWaterMark) {
-    Map<TopicPartition, OffsetAndMetadata> offsetsToCommit =
-        _consumerRecordsProcessor.safeOffsetsToCommit(offsets, ignoreHighWaterMark);
-    // If user did not consume any message before the first commit, in this case user will pass in the last
-    // committed message offsets. We simply use the last committed safe offset.
-    for (Map.Entry<TopicPartition, OffsetAndMetadata> entry : offsets.entrySet()) {
-      OffsetAndMetadata committed = _kafkaConsumer.committed(entry.getKey());
-      if (committed != null) {
-        Long committedUserOffset = LiKafkaClientsUtils.offsetFromWrappedMetadata(committed.metadata());
-        if (committedUserOffset != null && entry.getValue().offset() == committedUserOffset) {
-          long safeOffset = committed.offset();
-          String userMetadata = entry.getValue().metadata();
-          String wrappedMetadata = LiKafkaClientsUtils.wrapMetadataWithOffset(userMetadata, committedUserOffset);
-          offsetsToCommit.put(entry.getKey(), new OffsetAndMetadata(safeOffset, wrappedMetadata));
-        }
-      }
-    }
-
-    return offsetsToCommit;
-  }
 
   /**
    * A helper function that converts the last delivered offset map to the offset to commit.
@@ -622,6 +672,7 @@ public class LiKafkaConsumerImpl<K, V> implements LiKafkaConsumer<K, V> {
   private Map<TopicPartition, OffsetAndMetadata> currentOffsetAndMetadataMap() {
     Map<TopicPartition, OffsetAndMetadata> offsetAndMetadataMap = new HashMap<>();
     Map<TopicPartition, Long> delivered = _consumerRecordsProcessor.delivered();
+    Set<TopicPartition> knownPartitions = _consumerRecordsProcessor.knownPartitions();
     for (TopicPartition tp : _kafkaConsumer.assignment()) {
       if (delivered.containsKey(tp)) {
         // Case 1
@@ -629,28 +680,16 @@ public class LiKafkaConsumerImpl<K, V> implements LiKafkaConsumer<K, V> {
       } else {
         // No message has been delivered from the partition.
         Long earliestTrackedOffset = _consumerRecordsProcessor.earliestTrackedOffset(tp);
-        Long hw = _consumerRecordsProcessor.consumerHighWaterMarkForPartition(tp);
         if (earliestTrackedOffset != null) {
-          // We may need to update the high watermark in case there are two rebalances happened back to back, in that
-          // case we may lose high watermark if we don't fetch it from the server.
-          if (hw == null) {
-            OffsetAndMetadata committed = committed(tp);
-            if (committed != null) {
-              _consumerRecordsProcessor.setPartitionConsumerHighWaterMark(tp, committed.offset());
-            }
-          }
           // Case 2, some message was consumed. Use the earliest tracked offset to avoid losing messages.
           offsetAndMetadataMap.put(tp, new OffsetAndMetadata(position(tp), ""));
-        } else {
-          // No message was consumed.
-          if (hw == null) {
-            // Case 3, no message is consumed, no message is delivered. Do nothing to avoid overriding the committed
-            // high watermark on the server. We can also get the committed high watermark from the server, but it
-            // is unnecessary work.
-          } else {
-            // Case 4, user called seek(), we use the current position to commit.
+        } else if (knownPartitions.contains(tp)) {
+            // Case 4 user called seek() or we have not consumed anything on this partition,
+            // use the current position to commit.  This gets corrected later when computing the safe offsets if
+            // a consumer hwm exists in Kaka broker already.
             offsetAndMetadataMap.put(tp, new OffsetAndMetadata(position(tp), ""));
-          }
+        } else {
+          //Case 4.  Never consumed from partiton.
         }
       }
     }

--- a/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/consumer/LiKafkaConsumerRebalanceListener.java
+++ b/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/consumer/LiKafkaConsumerRebalanceListener.java
@@ -40,13 +40,18 @@ class LiKafkaConsumerRebalanceListener<K, V> implements ConsumerRebalanceListene
     // Record the partitions that might be revoked, if the partitions are really revoked, we need to clean up
     // the state.
     _partitionsRemoved.clear();
-    _consumerRecordsProcessor.clearAllConsumerHighWaterMarks();
     _partitionsRemoved.addAll(topicPartitions);
-    // Fire user listener.
-    _userListener.onPartitionsRevoked(topicPartitions);
-    // Commit offset if auto commit is enabled.
-    if (_autoCommitEnabled) {
-      _consumer.commitSync();
+
+    try {
+      // Fire user listener.
+      _userListener.onPartitionsRevoked(topicPartitions);
+
+      // Commit offset if auto commit is enabled.
+      if (_autoCommitEnabled) {
+        _consumer.commitSync();
+      }
+    } finally {
+      _consumerRecordsProcessor.clearAllConsumerHighWaterMarks();
     }
   }
 

--- a/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/consumer/LiOffsetResetStrategy.java
+++ b/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/consumer/LiOffsetResetStrategy.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2017 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License").  See License in the project root for license information.
+ */
+
+package com.linkedin.kafka.clients.consumer;
+
+/**
+ * Since enum are essentially final in Java, we are duplicating the values from
+ * the open-source equivalent {@link org.apache.kafka.clients.consumer.OffsetResetStrategy}
+ *
+ * This workaround needs to be provided until apache/kafka can support a closest reset policy,
+ * aka KIP-320 (https://cwiki.apache.org/confluence/display/KAFKA/KIP-320%3A+Allow+fetchers+to+detect+and+handle+log+truncation)
+ */
+public enum LiOffsetResetStrategy {
+  EARLIEST, LATEST, NONE, LICLOSEST
+}

--- a/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/consumer/LiOffsetResetStrategy.java
+++ b/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/consumer/LiOffsetResetStrategy.java
@@ -5,7 +5,7 @@
 package com.linkedin.kafka.clients.consumer;
 
 /**
- * Since enum are essentially final in Java, we are duplicating the values from
+ * Since enums are essentially final in Java, we are duplicating the values from
  * the open-source equivalent {@link org.apache.kafka.clients.consumer.OffsetResetStrategy}
  *
  * This workaround needs to be provided until apache/kafka can support a closest reset policy,

--- a/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/largemessage/MessageAssemblerImpl.java
+++ b/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/largemessage/MessageAssemblerImpl.java
@@ -9,8 +9,6 @@ import org.apache.kafka.common.serialization.Deserializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Map;
-
 import static com.linkedin.kafka.clients.largemessage.MessageAssembler.AssembleResult.INCOMPLETE_RESULT;
 
 
@@ -52,13 +50,8 @@ public class MessageAssemblerImpl implements MessageAssembler {
   }
 
   @Override
-  public Map<TopicPartition, Long> safeOffsets() {
-    return _messagePool.safeOffsets();
-  }
-
-  @Override
-  public long safeOffset(TopicPartition tp) {
-    return _messagePool.safeOffset(tp);
+  public long safeOffset(TopicPartition tp, long currentPosition) {
+    return _messagePool.safeOffset(tp, currentPosition);
   }
 
   @Override

--- a/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/producer/LiKafkaProducer.java
+++ b/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/producer/LiKafkaProducer.java
@@ -5,20 +5,19 @@
 package com.linkedin.kafka.clients.producer;
 
 import com.linkedin.kafka.clients.annotations.InterfaceOrigin;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.producer.Callback;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
-import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.Metric;
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.PartitionInfo;
-
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.ProducerFencedException;
 
@@ -51,6 +50,12 @@ public interface LiKafkaProducer<K, V> extends Producer<K, V> {
   @Override
   @InterfaceOrigin.ApacheKafka
   void flush();
+
+  /**
+   * Flush any accumulated records from the producer. If the close does not complete within the timeout, throws exception.
+   * TODO: This API is added as a HOTFIX until the API change is available in apache/kafka
+   */
+  void flush(long timeout, TimeUnit timeUnit);
 
   /**
    * {@inheritDoc}

--- a/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/producer/LiKafkaProducer.java
+++ b/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/producer/LiKafkaProducer.java
@@ -53,6 +53,7 @@ public interface LiKafkaProducer<K, V> extends Producer<K, V> {
 
   /**
    * Flush any accumulated records from the producer. If the close does not complete within the timeout, throws exception.
+   * If the underlying producer does not support bounded flush, this method defaults to {@link #flush()}
    * TODO: This API is added as a HOTFIX until the API change is available in apache/kafka
    */
   void flush(long timeout, TimeUnit timeUnit);

--- a/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/producer/LiKafkaProducerImpl.java
+++ b/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/producer/LiKafkaProducerImpl.java
@@ -284,6 +284,15 @@ public class LiKafkaProducerImpl<K, V> implements LiKafkaProducer<K, V> {
     _producer.flush();
   }
 
+  /**
+   * This method will flush all the message buffered in producer. The call blocks until timeout.
+   */
+  @Override
+  public void flush(long timeout, TimeUnit timeUnit) {
+    LOG.warn("LiKafkaProducerImpl does not support bounded flush. Calling flush() on producer, instead.");
+    _producer.flush();
+  }
+
   @Override
   public List<PartitionInfo> partitionsFor(String topic) {
     return _producer.partitionsFor(topic);

--- a/li-apache-kafka-clients/src/test/java/com/linkedin/kafka/clients/largemessage/ConsumerRecordsProcessorTest.java
+++ b/li-apache-kafka-clients/src/test/java/com/linkedin/kafka/clients/largemessage/ConsumerRecordsProcessorTest.java
@@ -316,7 +316,7 @@ public class ConsumerRecordsProcessorTest {
     MessageAssembler assembler = new MessageAssemblerImpl(5000, 100, false, segmentDeserializer);
     DeliveredMessageOffsetTracker deliveredMessageOffsetTracker = new DeliveredMessageOffsetTracker(4);
     ConsumerRecordsProcessor processor =  new ConsumerRecordsProcessor<>(assembler, stringDeserializer, errorThrowingDeserializer,
-                                                                          deliveredMessageOffsetTracker, null);
+                                                                          deliveredMessageOffsetTracker, null, (tp) -> null);
 
     StringSerializer stringSerializer = new StringSerializer();
     ConsumerRecord<byte[], byte[]> consumerRecord0 = new ConsumerRecord<>("topic", 0, 0, null,
@@ -404,7 +404,7 @@ public class ConsumerRecordsProcessorTest {
     Deserializer<LargeMessageSegment> segmentDeserializer = new DefaultSegmentDeserializer();
     MessageAssembler assembler = new MessageAssemblerImpl(5000, 100, false, segmentDeserializer);
     DeliveredMessageOffsetTracker deliveredMessageOffsetTracker = new DeliveredMessageOffsetTracker(4);
-    return new ConsumerRecordsProcessor<>(assembler, stringDeserializer, stringDeserializer, deliveredMessageOffsetTracker, null);
+    return new ConsumerRecordsProcessor<>(assembler, stringDeserializer, stringDeserializer, deliveredMessageOffsetTracker, null, (tp) -> null);
   }
 
   private byte[] wrapMessageBytes(Serializer<LargeMessageSegment> segmentSerializer, byte[] messageBytes) {


### PR DESCRIPTION
Major ones are:
-  Add bounded flush to LiKafkaProducer
- Expire large message segments when normal messages arrive.
-  LICLOSEST implementation & integration tests (introduced `LiOffsetResetStrategy` to avoid using `String`) 
- Don't retrieve the consumer high watermark for every partition on every offset commit.