### PR TITLE
Pull in Kafka 2.0 clients

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,7 @@ project.ext {
       url "https://github.com/linkedin/li-apache-kafka-clients"
     }
   }
-  kafkaVersion = "0.11.0.3"
+  kafkaVersion = "2.0.1"
 }
 
 subprojects {

--- a/integration-tests/src/test/java/com/linkedin/kafka/clients/consumer/LiKafkaConsumerIntegrationTest.java
+++ b/integration-tests/src/test/java/com/linkedin/kafka/clients/consumer/LiKafkaConsumerIntegrationTest.java
@@ -916,6 +916,8 @@ public class LiKafkaConsumerIntegrationTest extends AbstractKafkaClientsIntegrat
       consumer.assign(timestampsToSearch.keySet());
       Map<TopicPartition, OffsetAndTimestamp> offsets = consumer.offsetsForTimes(timestampsToSearch);
       for (Map.Entry<TopicPartition, OffsetAndTimestamp> entry : offsets.entrySet()) {
+        assertNotNull(entry.getValue(), "Failed to find offset for topic partition " + entry.getKey() +
+            " for timestamp " + timestampsToSearch.get(entry.getKey()));
         consumer.seek(entry.getKey(), entry.getValue().offset());
       }
 

--- a/integration-tests/src/test/java/com/linkedin/kafka/clients/consumer/LiKafkaConsumerIntegrationTest.java
+++ b/integration-tests/src/test/java/com/linkedin/kafka/clients/consumer/LiKafkaConsumerIntegrationTest.java
@@ -1321,7 +1321,8 @@ public class LiKafkaConsumerIntegrationTest extends AbstractKafkaClientsIntegrat
         produceRecordsWithKafkaProducer();
       }
       if (currentLso == initialLso) {
-        throw new IllegalStateException("nothing was truncated broker-side within timeout");
+        throw new IllegalStateException("nothing was truncated broker-side within timeout. LogStartOffset = " +
+            currentLso + " remains the same after " + giveUp + "ms.");
       }
       truncatedStartOffset = currentLso;
     }

--- a/integration-tests/src/test/java/com/linkedin/kafka/clients/consumer/LiKafkaConsumerSSLIntegrationTest.java
+++ b/integration-tests/src/test/java/com/linkedin/kafka/clients/consumer/LiKafkaConsumerSSLIntegrationTest.java
@@ -6,7 +6,7 @@ package com.linkedin.kafka.clients.consumer;
 
 import java.io.File;
 import java.io.IOException;
-import org.apache.kafka.common.protocol.SecurityProtocol;
+import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 

--- a/integration-tests/src/test/java/com/linkedin/kafka/clients/producer/LiKafkaProducerSSLIntegrationTest.java
+++ b/integration-tests/src/test/java/com/linkedin/kafka/clients/producer/LiKafkaProducerSSLIntegrationTest.java
@@ -6,7 +6,7 @@ package com.linkedin.kafka.clients.producer;
 
 import java.io.File;
 import java.io.IOException;
-import org.apache.kafka.common.protocol.SecurityProtocol;
+import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.testng.Assert;
 
 

--- a/kafka-test-harness/src/main/java/com/linkedin/kafka/clients/utils/tests/AbstractKafkaClientsIntegrationTestHarness.java
+++ b/kafka-test-harness/src/main/java/com/linkedin/kafka/clients/utils/tests/AbstractKafkaClientsIntegrationTestHarness.java
@@ -18,7 +18,7 @@ import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.network.Mode;
-import org.apache.kafka.common.protocol.SecurityProtocol;
+import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 

--- a/kafka-test-harness/src/main/java/com/linkedin/kafka/clients/utils/tests/AbstractKafkaIntegrationTestHarness.java
+++ b/kafka-test-harness/src/main/java/com/linkedin/kafka/clients/utils/tests/AbstractKafkaIntegrationTestHarness.java
@@ -11,7 +11,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.StringJoiner;
-import org.apache.kafka.common.protocol.SecurityProtocol;
+import org.apache.kafka.common.security.auth.SecurityProtocol;
 
 
 public abstract class AbstractKafkaIntegrationTestHarness extends AbstractZookeeperTestHarness {

--- a/kafka-test-harness/src/main/java/com/linkedin/kafka/clients/utils/tests/EmbeddedBroker.java
+++ b/kafka-test-harness/src/main/java/com/linkedin/kafka/clients/utils/tests/EmbeddedBroker.java
@@ -12,7 +12,7 @@ import java.util.HashMap;
 import java.util.Map;
 import org.apache.commons.io.FileUtils;
 import org.apache.kafka.common.network.ListenerName;
-import org.apache.kafka.common.protocol.SecurityProtocol;
+import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.apache.kafka.common.utils.Time;
 
 

--- a/kafka-test-harness/src/main/java/com/linkedin/kafka/clients/utils/tests/EmbeddedBrokerBuilder.java
+++ b/kafka-test-harness/src/main/java/com/linkedin/kafka/clients/utils/tests/EmbeddedBrokerBuilder.java
@@ -10,7 +10,7 @@ import java.util.Map;
 import java.util.StringJoiner;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.kafka.common.network.Mode;
-import org.apache.kafka.common.protocol.SecurityProtocol;
+import org.apache.kafka.common.security.auth.SecurityProtocol;
 
 
 public class EmbeddedBrokerBuilder {
@@ -67,7 +67,7 @@ public class EmbeddedBrokerBuilder {
     this.logRetentionMs = millis;
     return this;
   }
-  
+
   public EmbeddedBrokerBuilder enable(SecurityProtocol protocol) {
     switch (protocol) {
       case PLAINTEXT:

--- a/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/consumer/LiKafkaConsumer.java
+++ b/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/consumer/LiKafkaConsumer.java
@@ -7,10 +7,10 @@ package com.linkedin.kafka.clients.consumer;
 import com.linkedin.kafka.clients.annotations.InterfaceOrigin;
 import com.linkedin.kafka.clients.largemessage.LargeMessageSegment;
 import com.linkedin.kafka.clients.largemessage.errors.OffsetNotTrackedException;
-import com.linkedin.kafka.clients.largemessage.errors.RecordProcessingException;
 import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.clients.consumer.OffsetAndTimestamp;
 import org.apache.kafka.clients.consumer.OffsetCommitCallback;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.common.Metric;
@@ -18,10 +18,12 @@ import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 
+import java.time.Duration;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 
 /**
@@ -54,123 +56,64 @@ import java.util.regex.Pattern;
 public interface LiKafkaConsumer<K, V> extends Consumer<K, V> {
 
   /**
-   * Get the set of partitions currently assigned to this consumer. If subscription happened by directly assigning
-   * partitions using {@link #assign(Collection)} then this will simply return the same partitions that
-   * were assigned. If topic subscription was used, then this will give the set of topic partitions currently assigned
-   * to the consumer (which may be none if the assignment hasn't happened yet, or the partitions are in the
-   * process of getting reassigned).
-   *
-   * @return The set of partitions currently assigned to this consumer
+   * {@inheritDoc}
    */
+  @Override
   @InterfaceOrigin.ApacheKafka
   Set<TopicPartition> assignment();
 
   /**
-   * Get the current subscription. Will return the same topics used in the most recent call to
-   * {@link #subscribe(Collection, ConsumerRebalanceListener)}, or an empty set if no such call has been made.
-   *
-   * @return The set of topics currently subscribed to
+   * {@inheritDoc}
    */
+  @Override
   @InterfaceOrigin.ApacheKafka
   Set<String> subscription();
 
   /**
-   * Subscribe to the given list of topics to get dynamically assigned partitions.
-   * <b>Topic subscriptions are not incremental. This list will replace the current
-   * assignment (if there is one).</b> It is not possible to combine topic subscription with group management
-   * with manual partition assignment through {@link #assign(Collection)}.
-   * <p>
-   * If the given list of topics is empty, it is treated the same as {@link #unsubscribe()}.
-   * <p>
-   * This is a short-hand for {@link #subscribe(Collection, ConsumerRebalanceListener)}, which
-   * uses a noop listener. If you need the ability to either seek to particular offsets, you should prefer
-   * {@link #subscribe(Collection, ConsumerRebalanceListener)}, since group rebalances will cause partition offsets
-   * to be reset. You should also prefer to provide your own listener if you are doing your own offset
-   * management since the listener gives you an opportunity to commit offsets before a rebalance finishes.
+   * {@inheritDoc}
    * <p>
    * In order to support large message, the consumer tracks all the consumed messages for each partition. When the
    * user no longer subscribes to a new set of topics, the consumer will discard all the tracked messages of the
    * partitions of that topic.
-   *
-   * @param topics The list of topics to subscribe to
    */
+  @Override
   @InterfaceOrigin.ApacheKafka
   void subscribe(Collection<String> topics);
 
   /**
-   * Subscribe to the given list of topics to get dynamically
-   * assigned partitions. <b>Topic subscriptions are not incremental. This list will replace the current
-   * assignment (if there is one).</b> Note that it is not possible to combine topic subscription with group management
-   * with manual partition assignment through {@link #assign(Collection)}.
-   * <p>
-   * If the given list of topics is empty, it is treated the same as {@link #unsubscribe()}.
-   * <p>
-   * As part of group management, the consumer will keep track of the list of consumers that belong to a particular
-   * group and will trigger a rebalance operation if one of the following events trigger -
-   * <ul>
-   * <li>Number of partitions change for any of the subscribed list of topics
-   * <li>Topic is created or deleted
-   * <li>An existing member of the consumer group dies
-   * <li>A new member is added to an existing consumer group via the join API
-   * </ul>
-   * <p>
-   * When any of these events are triggered, the provided listener will be invoked first to indicate that
-   * the consumer's assignment has been revoked, and then again when the new assignment has been received.
-   * Note that this listener will immediately override any listener set in a previous call to subscribe.
-   * It is guaranteed, however, that the partitions revoked/assigned through this interface are from topics
-   * subscribed in this call. See {@link ConsumerRebalanceListener} for more details.
+   * {@inheritDoc}
    * <p>
    * In order to support large message, the consumer tracks all the consumed messages for each partition. When the
    * user no longer subscribes to a new set of topics, the consumer will discard all the tracked messages of the
    * partitions of that topic.
-   *
-   * @param topics   The list of topics to subscribe to
-   * @param callback Non-null listener instance to get notifications on partition assignment/revocation for the
-   *                 subscribed topics
    */
+  @Override
   @InterfaceOrigin.ApacheKafka
   void subscribe(Collection<String> topics, ConsumerRebalanceListener callback);
 
   /**
-   * Manually assign a list of partition to this consumer. This interface does not allow for incremental assignment
-   * and will replace the previous assignment (if there is one).
-   * <p>
-   * Manual topic assignment through this method does not use the consumer's group management
-   * functionality. As such, there will be no rebalance operation triggered when group membership or cluster and topic
-   * metadata change. Note that it is not possible to use both manual partition assignment with {@link #assign(Collection)}
-   * and group assignment with {@link #subscribe(Collection, ConsumerRebalanceListener)}.
+   * {@inheritDoc}
    * <p>
    * In order to support large message, the consumer tracks all the consumed messages for each partition. When the
    * the consumer is no longer assigned a partition, the consumer will discard all the tracked messages of the
    * partitions of that topic.
    *
-   * @param partitions The list of partitions to assign this consumer
    */
-  @InterfaceOrigin.ApacheKafka
-  void assign(Collection<TopicPartition> partitions);
-
-  /**
-   * Subscribe to all topics matching specified pattern to get dynamically assigned partitions. The pattern matching will
-   * be done periodically against topics existing at the time of check.
-   * <p>
-   * As part of group management, the consumer will keep track of the list of consumers that
-   * belong to a particular group and will trigger a rebalance operation if one of the
-   * following events trigger -
-   * <ul>
-   * <li>Number of partitions change for any of the subscribed list of topics
-   * <li>Topic is created or deleted
-   * <li>An existing member of the consumer group dies
-   * <li>A new member is added to an existing consumer group via the join API
-   * </ul>
-   * <p>
-   * In order to support large message, the consumer tracks all the consumed messages for each partition. When the
-   * user no longer subscribes to a new set of topics, the consumer will discard all the tracked messages of the
-   * partitions of that topic.
-   *
-   * @param pattern Pattern to subscribe to
-   */
+  @Override
   @InterfaceOrigin.ApacheKafka
   void subscribe(Pattern pattern, ConsumerRebalanceListener callback);
+
+  /**
+   * {@inheritDoc}
+   * <p>
+   * In order to support large message, the consumer tracks all the consumed messages for each partition. When the
+   * the consumer is no longer assigned a partition, the consumer will discard all the tracked messages of the
+   * partitions of that topic.
+   *
+   */
+  @Override
+  @InterfaceOrigin.ApacheKafka
+  void subscribe(Pattern pattern);
 
   /**
    * Unsubscribe from topics currently subscribed with {@link #subscribe(Collection)}. This
@@ -183,126 +126,83 @@ public interface LiKafkaConsumer<K, V> extends Consumer<K, V> {
   void unsubscribe();
 
   /**
-   * Fetch data for the topics or partitions specified using one of the subscribe/assign APIs. It is an error to not have
-   * subscribed to any topics or partitions before polling for data.
+   * {@inheritDoc}
    * <p>
-   * On each poll, consumer will try to use the last consumed offset as the starting offset and fetch sequentially. The last
-   * consumed offset can be manually set through {@link #seek(TopicPartition, long)} or automatically set as the last committed
-   * offset for the subscribed list of partitions
+   * In order to support large message, the consumer tracks all the consumed messages for each partition. When the
+   * the consumer is no longer assigned a partition, the consumer will discard all the tracked messages of the
+   * partitions of that topic.
    *
-   * @param timeout The time, in milliseconds, spent waiting in poll if data is not available in the buffer.
-   *                If 0, returns immediately with any records that are available currently in the buffer, else returns empty.
-   *                Must not be negative.
-   * @return map of topic to records since the last fetch for the subscribed list of topics and partitions
-   * @throws org.apache.kafka.clients.consumer.InvalidOffsetException if the offset for a partition or set of
-   *                                                                  partitions is undefined or out of range and no offset
-   *                                                                  reset policy has been configured
-   * @throws org.apache.kafka.common.errors.WakeupException           if {@link #wakeup()} is called before or while this
-   *                                                                  function is called
-   * @throws org.apache.kafka.common.errors.AuthorizationException    if caller does Read access to any of the subscribed
-   *                                                                  topics or to the configured groupId
-   * @throws org.apache.kafka.common.KafkaException                   for any other unrecoverable errors (e.g. invalid groupId or
-   *                                                                  session timeout, errors deserializing key/value
-   *                                                                  pairs, or any new error cases in future versions)
-   * @throws RecordProcessingException
-   *                                                                  When RecordProcessingException is thrown,
-   *                                                                  user can choose to catch it and continue to poll
-   *                                                                  if they want to skip the message that has thrown
-   *                                                                  exception.
    */
+  @Override
+  @InterfaceOrigin.ApacheKafka
+  void assign(Collection<TopicPartition> partitions);
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
   @InterfaceOrigin.ApacheKafka
   ConsumerRecords<K, V> poll(long timeout);
 
   /**
-   * Commit offsets returned on the last {@link #poll(long) poll()} for all the subscribed list of topics and partitions.
-   * <p>
-   * This commits offsets only to Kafka. The offsets committed using this API will be used on the first fetch after
-   * every rebalance and also on startup. As such, if you need to store offsets in anything other than Kafka, this API
-   * should not be used.
-   * <p>
-   * This is a synchronous commits and will block until either the commit succeeds or an unrecoverable error is
-   * encountered (in which case it is thrown to the caller).
-   *
-   * @throws org.apache.kafka.clients.consumer.CommitFailedException if the commit failed and cannot be retried.
-   *                                                                 This can only occur if you are using automatic group
-   *                                                                 management with {@link #subscribe(Collection)},
-   *                                                                 or if there is an active group with the same groupId
-   *                                                                 which is using group management.
-   * @throws org.apache.kafka.common.errors.WakeupException          if {@link #wakeup()} is called before or while this
-   *                                                                 function is called
-   * @throws org.apache.kafka.common.errors.AuthorizationException   if not authorized to the topic or to the
-   *                                                                 configured groupId
-   * @throws org.apache.kafka.common.KafkaException                  for any other unrecoverable errors (e.g. if offset metadata
-   *                                                                 is too large or if the committed offset is invalid).
+   * {@inheritDoc}
    */
+  @Override
+  @InterfaceOrigin.ApacheKafka
+  ConsumerRecords<K, V> poll(Duration timeout);
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
   @InterfaceOrigin.ApacheKafka
   void commitSync();
 
   /**
-   * Commit the specified offsets for the specified list of topics and partitions.
-   * <p>
-   * This commits offsets to Kafka. The offsets committed using this API will be used on the first fetch after every
-   * rebalance and also on startup. As such, if you need to store offsets in anything other than Kafka, this API
-   * should not be used. The committed offset should be the next message your application will consume,
-   * i.e. lastProcessedMessageOffset + 1.
-   * <p>
-   * This is a synchronous commits and will block until either the commit succeeds or an unrecoverable error is
-   * encountered (in which case it is thrown to the caller).
-   * <p>
-   * This method is large message transparent.
+   * {@inheritDoc}
+   */
+  @Override
+  @InterfaceOrigin.ApacheKafka
+  void commitSync(Duration timeout);
+
+  /**
+   * {@inheritDoc}
    * <p>
    * With large message support, the consumer will internally translate the user provided offsets to the safe
    * offsets for the corresponding partitions (see {@link #safeOffset(TopicPartition, long)}. The actual offset
    * committed to Kafka can be retrieved through method {@link #committedSafeOffset(TopicPartition)}.
-   *
-   * @param offsets A map of offsets by partition with associated metadata
-   * @throws org.apache.kafka.clients.consumer.CommitFailedException if the commit failed and cannot be retried.
-   *                                                                 This can only occur if you are using automatic group
-   *                                                                 management with {@link #subscribe(Collection)},
-   *                                                                 or if there is an active group with the same groupId
-   *                                                                 which is using group management.
-   * @throws org.apache.kafka.common.errors.WakeupException          if {@link #wakeup()} is called before or while this
-   *                                                                 function is called
-   * @throws org.apache.kafka.common.errors.AuthorizationException   if not authorized to the topic or to the
-   *                                                                 configured groupId
-   * @throws org.apache.kafka.common.KafkaException                  for any other unrecoverable errors (e.g. if offset metadata
-   *                                                                 is too large or if the committed offset is invalid).
    */
+  @Override
   @InterfaceOrigin.ApacheKafka
   void commitSync(Map<TopicPartition, OffsetAndMetadata> offsets);
 
   /**
-   * Commit offsets returned on the last {@link #poll(long) poll()} for all the subscribed list of topics and partition.
-   * Same as {@link #commitAsync(OffsetCommitCallback) commitAsync(null)}
+   * {@inheritDoc}
+   * <p>
+   * With large message support, the consumer will internally translate the user provided offsets to the safe
+   * offsets for the corresponding partitions (see {@link #safeOffset(TopicPartition, long)}. The actual offset
+   * committed to Kafka can be retrieved through method {@link #committedSafeOffset(TopicPartition)}.
    */
+  @Override
+  @InterfaceOrigin.ApacheKafka
+  void commitSync(final Map<TopicPartition, OffsetAndMetadata> offsets, final Duration timeout);
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
   @InterfaceOrigin.ApacheKafka
   void commitAsync();
 
   /**
-   * Commit offsets returned on the last {@link #poll(long) poll()} for the subscribed list of topics and partitions.
-   * <p>
-   * This commits offsets only to Kafka. The offsets committed using this API will be used on the first fetch after
-   * every rebalance and also on startup. As such, if you need to store offsets in anything other than Kafka, this API
-   * should not be used.
-   * <p>
-   * This is an asynchronous call and will not block. Any errors encountered are either passed to the callback
-   * (if provided) or discarded.
-   *
-   * @param callback Callback to invoke when the commit completes
+   * {@inheritDoc}
    */
+  @Override
   @InterfaceOrigin.ApacheKafka
   void commitAsync(OffsetCommitCallback callback);
 
   /**
-   * Commit the specified offsets for the specified list of topics and partitions to Kafka.
-   * <p>
-   * This commits offsets to Kafka. The offsets committed using this API will be used on the first fetch after every
-   * rebalance and also on startup. As such, if you need to store offsets in anything other than Kafka, this API
-   * should not be used. The committed offset should be the next message your application will consume,
-   * i.e. lastProcessedMessageOffset + 1.
-   * <p>
-   * This is an asynchronous call and will not block. Any errors encountered are either passed to the callback
-   * (if provided) or discarded.
+   * {@inheritDoc}
    * <p>
    * This method is large message transparent.
    * <p>
@@ -310,18 +210,13 @@ public interface LiKafkaConsumer<K, V> extends Consumer<K, V> {
    * offsets for the corresponding partitions (see {@link #safeOffset(TopicPartition, long)}. The actual offset
    * committed to Kafka can be retrieved through method {@link #committedSafeOffset(TopicPartition)}. The arguments
    * passed to the callback is large message transparent.
-   *
-   * @param offsets  A map of offsets by partition with associate metadata. This map will be copied internally, so it
-   *                 is safe to mutate the map after returning.
-   * @param callback Callback to invoke when the commit completes
    */
+  @Override
   @InterfaceOrigin.ApacheKafka
   void commitAsync(Map<TopicPartition, OffsetAndMetadata> offsets, OffsetCommitCallback callback);
 
   /**
-   * Overrides the fetch offsets that the consumer will use on the next {@link #poll(long) poll(timeout)}. If this API
-   * is invoked for the same partition more than once, the latest offset will be used on the next poll(). Note that
-   * you may lose data if this API is arbitrarily used in the middle of consumption, to reset the fetch offsets
+   * {@inheritDoc}
    * <p>
    * With large message support, the consumer maintains the internal state for the consumed message of each
    * partition. With the internal state, the consumer guarantees the messages after the offset sought to will
@@ -342,27 +237,26 @@ public interface LiKafkaConsumer<K, V> extends Consumer<K, V> {
    * When this method returned without throwing exception, the internally tracked offsets for this partition are
    * discarded.
    */
+  @Override
   @InterfaceOrigin.ApacheKafka
   void seek(TopicPartition partition, long offset);
 
   /**
-   * Seek to the first offset for each of the given partitions. This function evaluates lazily, seeking to the
-   * first offset in all partitions only when {@link #poll(long)} or {@link #position(TopicPartition)} are called.
-   * If no partition is provided, seek to the first offset for all of the currently assigned partitions.
+   * {@inheritDoc}
    * <p>
    * Because the broker is not large message aware, it is possible that when user seek to the beginning of the log
    * and start to consume, some of the large message segments has been expired on the broker side and some segments
    * are still available. Therefore it is not guaranteed that user will see the same sequence of messages when they
    * seek to the beginning of the log.
    */
+  @Override
   @InterfaceOrigin.ApacheKafka
   void seekToBeginning(Collection<TopicPartition> partitions);
 
   /**
-   * Seek to the last offset for each of the given partitions. This function evaluates lazily, seeking to the
-   * final offset in all partitions only when {@link #poll(long)} or {@link #position(TopicPartition)} are called.
-   * If no partition is provided, seek to the final offset for all of the currently assigned partitions.
+   * {@inheritDoc}
    */
+  @Override
   @InterfaceOrigin.ApacheKafka
   void seekToEnd(Collection<TopicPartition> partitions);
 
@@ -371,46 +265,37 @@ public interface LiKafkaConsumer<K, V> extends Consumer<K, V> {
    * <p>
    * This method is large message aware. This method is synchronous and takes effect immediately. If there is
    * no offset committed for some of the partitions, an exception will be thrown.
-   *
-   * @param partitions The partitions to seek to committed offsets.
-   * @throws org.apache.kafka.clients.consumer.NoOffsetForPartitionException if no offset has been committed before.
    */
   @InterfaceOrigin.LiKafkaClients
   void seekToCommitted(Collection<TopicPartition> partitions);
 
   /**
-   * Get the offset of the <i>next record</i> that will be fetched (if a record with that offset exists).
-   *
-   * @param partition The partition to get the position for
-   * @return The offset
-   * @throws org.apache.kafka.clients.consumer.InvalidOffsetException if no offset is currently defined for
-   *                                                                  the partition
-   * @throws org.apache.kafka.common.errors.WakeupException           if {@link #wakeup()} is called before or while this
-   *                                                                  function is called
-   * @throws org.apache.kafka.common.errors.AuthorizationException    if not authorized to the topic or to the
-   *                                                                  configured groupId
-   * @throws org.apache.kafka.common.KafkaException                   for any other unrecoverable errors
+   * {@inheritDoc}
    */
+  @Override
   @InterfaceOrigin.ApacheKafka
   long position(TopicPartition partition);
 
   /**
-   * Get the last committed offset for the given partition (whether the commit happened by this process or
-   * another). This offset will be used as the position for the consumer in the event of a failure.
-   * <p>
-   * This call may block to do a remote call if the partition in question isn't assigned to this consumer or if the
-   * consumer hasn't yet initialized its cache of committed offsets.
-   *
-   * @param partition The partition to check
-   * @return The last committed offset and metadata or null if there was no prior commit
-   * @throws org.apache.kafka.common.errors.WakeupException        if {@link #wakeup()} is called before or while this
-   *                                                               function is called
-   * @throws org.apache.kafka.common.errors.AuthorizationException if not authorized to the topic or to the
-   *                                                               configured groupId
-   * @throws org.apache.kafka.common.KafkaException                for any other unrecoverable errors
+   * {@inheritDoc}
    */
+  @Override
+  @InterfaceOrigin.ApacheKafka
+  long position(TopicPartition partition, final Duration timeout);
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
   @InterfaceOrigin.ApacheKafka
   OffsetAndMetadata committed(TopicPartition partition);
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  @InterfaceOrigin.ApacheKafka
+  OffsetAndMetadata committed(TopicPartition partition, final Duration timeout);
 
   /**
    * With large message support, the consumer makes sure the offset committed to Kafka are the safe offsets
@@ -428,67 +313,58 @@ public interface LiKafkaConsumer<K, V> extends Consumer<K, V> {
   Long committedSafeOffset(TopicPartition partition);
 
   /**
-   * Get the metrics kept by the consumer
+   * {@inheritDoc}
    */
+  @Override
   @InterfaceOrigin.ApacheKafka
   Map<MetricName, ? extends Metric> metrics();
 
   /**
-   * Get metadata about the partitions for a given topic. This method will issue a remote call to the server if it
-   * does not already have any metadata about the given topic.
-   *
-   * @param topic The topic to get partition metadata for
-   * @return The list of partitions
-   * @throws org.apache.kafka.common.errors.WakeupException        if {@link #wakeup()} is called before or while this
-   *                                                               function is called
-   * @throws org.apache.kafka.common.errors.AuthorizationException if not authorized to the specified topic
-   * @throws org.apache.kafka.common.errors.TimeoutException       if the topic metadata could not be fetched before
-   *                                                               expiration of the configured request timeout
-   * @throws org.apache.kafka.common.KafkaException                for any other unrecoverable errors
+   * {@inheritDoc}
    */
+  @Override
   @InterfaceOrigin.ApacheKafka
   List<PartitionInfo> partitionsFor(String topic);
 
   /**
-   * Get metadata about partitions for all topics that the user is authorized to view. This method will issue a
-   * remote call to the server.
-   *
-   * @return The map of topics and its partitions
-   * @throws org.apache.kafka.common.errors.WakeupException  if {@link #wakeup()} is called before or while this
-   *                                                         function is called
-   * @throws org.apache.kafka.common.errors.TimeoutException if the topic metadata could not be fetched before
-   *                                                         expiration of the configured request timeout
-   * @throws org.apache.kafka.common.KafkaException          for any other unrecoverable errors
+   * {@inheritDoc}
    */
+  @Override
+  @InterfaceOrigin.ApacheKafka
+  List<PartitionInfo> partitionsFor(String topic, Duration timeout);
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
   @InterfaceOrigin.ApacheKafka
   Map<String, List<PartitionInfo>> listTopics();
 
   /**
-   * Get the set of partitions that were previously paused by a call to {@link #pause(Collection)}.
-   *
-   * @return The set of paused partitions
+   * {@inheritDoc}
    */
+  @Override
+  @InterfaceOrigin.ApacheKafka
+  Map<String, List<PartitionInfo>> listTopics(Duration timeout);
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
   @InterfaceOrigin.ApacheKafka
   Set<TopicPartition> paused();
 
   /**
-   * Suspend fetching from the requested partitions. Future calls to {@link #poll(long)} will not return
-   * any records from these partitions until they have been resumed using {@link #resume(Collection)}.
-   * Note that this method does not affect partition subscription. In particular, it does not cause a group
-   * rebalance when automatic assignment is used.
-   *
-   * @param partitions The partitions which should be paused
+   * {@inheritDoc}
    */
+  @Override
   @InterfaceOrigin.ApacheKafka
   void pause(Collection<TopicPartition> partitions);
 
   /**
-   * Resume specified partitions which have been paused with {@link #pause(Collection)}. New calls to
-   * {@link #poll(long)} will return records from these partitions if there are any to be fetched.
-   * If the partitions were not previously paused, this method is a no-op.
-   *
-   * @param partitions The partitions which should be resumed
+   * {@inheritDoc}
    */
+  @Override
   @InterfaceOrigin.ApacheKafka
   void resume(Collection<TopicPartition> partitions);
 
@@ -570,16 +446,72 @@ public interface LiKafkaConsumer<K, V> extends Consumer<K, V> {
   Map<TopicPartition, Long> safeOffsets();
 
   /**
-   * Close the consumer, waiting indefinitely for any needed cleanup. If auto-commit is enabled, this
-   * will commit the current offsets. Note that {@link #wakeup()} cannot be use to interrupt close.
+   * {@inheritDoc}
    */
+  @Override
+  @InterfaceOrigin.ApacheKafka
+  Map<TopicPartition, OffsetAndTimestamp> offsetsForTimes(Map<TopicPartition, Long> timestampsToSearch);
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  @InterfaceOrigin.ApacheKafka
+  Map<TopicPartition, OffsetAndTimestamp> offsetsForTimes(Map<TopicPartition, Long> timestampsToSearch, Duration timeout);
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  @InterfaceOrigin.ApacheKafka
+  Map<TopicPartition, Long> beginningOffsets(Collection<TopicPartition> partitions);
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  @InterfaceOrigin.ApacheKafka
+  Map<TopicPartition, Long> beginningOffsets(Collection<TopicPartition> partitions, Duration timeout);
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  @InterfaceOrigin.ApacheKafka
+  Map<TopicPartition, Long> endOffsets(Collection<TopicPartition> partitions);
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  @InterfaceOrigin.ApacheKafka
+  Map<TopicPartition, Long> endOffsets(Collection<TopicPartition> partitions, Duration timeout);
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
   @InterfaceOrigin.ApacheKafka
   void close();
 
   /**
-   * Wakeup the consumer. This method is thread-safe and is useful in particular to abort a long poll.
-   * The thread which is blocking in an operation will throw {@link org.apache.kafka.common.errors.WakeupException}.
+   * {@inheritDoc}
    */
+  @Override
+  @InterfaceOrigin.ApacheKafka
+  void close(long timeout, TimeUnit unit);
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  @InterfaceOrigin.ApacheKafka
+  void close(Duration timeout);
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
   @InterfaceOrigin.ApacheKafka
   void wakeup();
 }

--- a/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/consumer/LiKafkaConsumer.java
+++ b/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/consumer/LiKafkaConsumer.java
@@ -8,22 +8,14 @@ import com.linkedin.kafka.clients.annotations.InterfaceOrigin;
 import com.linkedin.kafka.clients.largemessage.LargeMessageSegment;
 import com.linkedin.kafka.clients.largemessage.errors.OffsetNotTrackedException;
 import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
-import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
-import org.apache.kafka.clients.consumer.OffsetAndTimestamp;
 import org.apache.kafka.clients.consumer.OffsetCommitCallback;
 import org.apache.kafka.clients.consumer.Consumer;
-import org.apache.kafka.common.Metric;
-import org.apache.kafka.common.MetricName;
-import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 
 import java.time.Duration;
 import java.util.Collection;
-import java.util.List;
 import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 
 /**
@@ -54,20 +46,6 @@ import java.util.regex.Pattern;
  * be handy. Please read the documentation of the corresponding method to ensure correct usage.
  */
 public interface LiKafkaConsumer<K, V> extends Consumer<K, V> {
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  @InterfaceOrigin.ApacheKafka
-  Set<TopicPartition> assignment();
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  @InterfaceOrigin.ApacheKafka
-  Set<String> subscription();
 
   /**
    * {@inheritDoc}
@@ -116,12 +94,12 @@ public interface LiKafkaConsumer<K, V> extends Consumer<K, V> {
   void subscribe(Pattern pattern);
 
   /**
-   * Unsubscribe from topics currently subscribed with {@link #subscribe(Collection)}. This
-   * also clears any partitions directly assigned through {@link #assign(Collection)}.
+   * {@inheritDoc}
    * <p>
    * In order to support large message, the consumer maintains some state internally for each partition. This method
    * will clear all the internal state maintained for large messages.
    */
+  @Override
   @InterfaceOrigin.ApacheKafka
   void unsubscribe();
 
@@ -136,34 +114,6 @@ public interface LiKafkaConsumer<K, V> extends Consumer<K, V> {
   @Override
   @InterfaceOrigin.ApacheKafka
   void assign(Collection<TopicPartition> partitions);
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  @InterfaceOrigin.ApacheKafka
-  ConsumerRecords<K, V> poll(long timeout);
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  @InterfaceOrigin.ApacheKafka
-  ConsumerRecords<K, V> poll(Duration timeout);
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  @InterfaceOrigin.ApacheKafka
-  void commitSync();
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  @InterfaceOrigin.ApacheKafka
-  void commitSync(Duration timeout);
 
   /**
    * {@inheritDoc}
@@ -186,20 +136,6 @@ public interface LiKafkaConsumer<K, V> extends Consumer<K, V> {
   @Override
   @InterfaceOrigin.ApacheKafka
   void commitSync(final Map<TopicPartition, OffsetAndMetadata> offsets, final Duration timeout);
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  @InterfaceOrigin.ApacheKafka
-  void commitAsync();
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  @InterfaceOrigin.ApacheKafka
-  void commitAsync(OffsetCommitCallback callback);
 
   /**
    * {@inheritDoc}
@@ -254,13 +190,6 @@ public interface LiKafkaConsumer<K, V> extends Consumer<K, V> {
   void seekToBeginning(Collection<TopicPartition> partitions);
 
   /**
-   * {@inheritDoc}
-   */
-  @Override
-  @InterfaceOrigin.ApacheKafka
-  void seekToEnd(Collection<TopicPartition> partitions);
-
-  /**
    * Seek to the committed offsets of this consumer group for the given partitions.
    * <p>
    * This method is large message aware. This method is synchronous and takes effect immediately. If there is
@@ -268,34 +197,6 @@ public interface LiKafkaConsumer<K, V> extends Consumer<K, V> {
    */
   @InterfaceOrigin.LiKafkaClients
   void seekToCommitted(Collection<TopicPartition> partitions);
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  @InterfaceOrigin.ApacheKafka
-  long position(TopicPartition partition);
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  @InterfaceOrigin.ApacheKafka
-  long position(TopicPartition partition, final Duration timeout);
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  @InterfaceOrigin.ApacheKafka
-  OffsetAndMetadata committed(TopicPartition partition);
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  @InterfaceOrigin.ApacheKafka
-  OffsetAndMetadata committed(TopicPartition partition, final Duration timeout);
 
   /**
    * With large message support, the consumer makes sure the offset committed to Kafka are the safe offsets
@@ -311,62 +212,6 @@ public interface LiKafkaConsumer<K, V> extends Consumer<K, V> {
    */
   @InterfaceOrigin.LiKafkaClients
   Long committedSafeOffset(TopicPartition partition);
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  @InterfaceOrigin.ApacheKafka
-  Map<MetricName, ? extends Metric> metrics();
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  @InterfaceOrigin.ApacheKafka
-  List<PartitionInfo> partitionsFor(String topic);
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  @InterfaceOrigin.ApacheKafka
-  List<PartitionInfo> partitionsFor(String topic, Duration timeout);
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  @InterfaceOrigin.ApacheKafka
-  Map<String, List<PartitionInfo>> listTopics();
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  @InterfaceOrigin.ApacheKafka
-  Map<String, List<PartitionInfo>> listTopics(Duration timeout);
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  @InterfaceOrigin.ApacheKafka
-  Set<TopicPartition> paused();
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  @InterfaceOrigin.ApacheKafka
-  void pause(Collection<TopicPartition> partitions);
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  @InterfaceOrigin.ApacheKafka
-  void resume(Collection<TopicPartition> partitions);
 
   /**
    * This method is to help the users that want to checkpoint the offsets outside of Kafka. It returns the safe offset
@@ -444,74 +289,4 @@ public interface LiKafkaConsumer<K, V> extends Consumer<K, V> {
    */
   @InterfaceOrigin.LiKafkaClients
   Map<TopicPartition, Long> safeOffsets();
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  @InterfaceOrigin.ApacheKafka
-  Map<TopicPartition, OffsetAndTimestamp> offsetsForTimes(Map<TopicPartition, Long> timestampsToSearch);
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  @InterfaceOrigin.ApacheKafka
-  Map<TopicPartition, OffsetAndTimestamp> offsetsForTimes(Map<TopicPartition, Long> timestampsToSearch, Duration timeout);
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  @InterfaceOrigin.ApacheKafka
-  Map<TopicPartition, Long> beginningOffsets(Collection<TopicPartition> partitions);
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  @InterfaceOrigin.ApacheKafka
-  Map<TopicPartition, Long> beginningOffsets(Collection<TopicPartition> partitions, Duration timeout);
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  @InterfaceOrigin.ApacheKafka
-  Map<TopicPartition, Long> endOffsets(Collection<TopicPartition> partitions);
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  @InterfaceOrigin.ApacheKafka
-  Map<TopicPartition, Long> endOffsets(Collection<TopicPartition> partitions, Duration timeout);
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  @InterfaceOrigin.ApacheKafka
-  void close();
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  @InterfaceOrigin.ApacheKafka
-  void close(long timeout, TimeUnit unit);
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  @InterfaceOrigin.ApacheKafka
-  void close(Duration timeout);
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  @InterfaceOrigin.ApacheKafka
-  void wakeup();
 }

--- a/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/producer/LiKafkaProducer.java
+++ b/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/producer/LiKafkaProducer.java
@@ -5,21 +5,8 @@
 package com.linkedin.kafka.clients.producer;
 
 import com.linkedin.kafka.clients.annotations.InterfaceOrigin;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
-import org.apache.kafka.clients.consumer.OffsetAndMetadata;
-import org.apache.kafka.clients.producer.Callback;
 import org.apache.kafka.clients.producer.Producer;
-import org.apache.kafka.clients.producer.ProducerRecord;
-import org.apache.kafka.clients.producer.RecordMetadata;
-import org.apache.kafka.common.Metric;
-import org.apache.kafka.common.MetricName;
-import org.apache.kafka.common.PartitionInfo;
-import org.apache.kafka.common.TopicPartition;
-import org.apache.kafka.common.errors.ProducerFencedException;
 
 
 /**
@@ -29,98 +16,11 @@ import org.apache.kafka.common.errors.ProducerFencedException;
  * @see LiKafkaProducerImpl
  */
 public interface LiKafkaProducer<K, V> extends Producer<K, V> {
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  @InterfaceOrigin.ApacheKafka
-  Future<RecordMetadata> send(ProducerRecord<K, V> record);
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  @InterfaceOrigin.ApacheKafka
-  Future<RecordMetadata> send(ProducerRecord<K, V> record, Callback callback);
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  @InterfaceOrigin.ApacheKafka
-  void flush();
-
   /**
    * Flush any accumulated records from the producer. If the close does not complete within the timeout, throws exception.
    * If the underlying producer does not support bounded flush, this method defaults to {@link #flush()}
    * TODO: This API is added as a HOTFIX until the API change is available in apache/kafka
    */
+  @InterfaceOrigin.LiKafkaClients
   void flush(long timeout, TimeUnit timeUnit);
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  @InterfaceOrigin.ApacheKafka
-  List<PartitionInfo> partitionsFor(String topic);
-
-  Map<String, List<PartitionInfo>> partitionsFor(Set<String> topics);
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  @InterfaceOrigin.ApacheKafka
-  Map<MetricName, ? extends Metric> metrics();
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  @InterfaceOrigin.ApacheKafka
-  void close();
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  @InterfaceOrigin.ApacheKafka
-  void close(long timeout, TimeUnit unit);
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  @InterfaceOrigin.ApacheKafka
-  void initTransactions();
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  @InterfaceOrigin.ApacheKafka
-  void beginTransaction() throws ProducerFencedException;
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  @InterfaceOrigin.ApacheKafka
-  void sendOffsetsToTransaction(Map<TopicPartition, OffsetAndMetadata> offsets, String consumerGroupId) throws ProducerFencedException;
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  @InterfaceOrigin.ApacheKafka
-  void commitTransaction() throws ProducerFencedException;
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  @InterfaceOrigin.ApacheKafka
-  void abortTransaction() throws ProducerFencedException;
-
 }

--- a/li-apache-kafka-clients/src/test/java/com/linkedin/kafka/clients/largemessage/LageMessageCallbackTest.java
+++ b/li-apache-kafka-clients/src/test/java/com/linkedin/kafka/clients/largemessage/LageMessageCallbackTest.java
@@ -33,10 +33,10 @@ public class LageMessageCallbackTest {
     });
 
     for (int i = 0; i < numSegments - 1; i++) {
-      callback.onCompletion(new RecordMetadata(new TopicPartition("topic", 0), 0L, 0L, 0L, 0, 0, 0), null);
+      callback.onCompletion(new RecordMetadata(new TopicPartition("topic", 0), 0L, 0L, 0L, 0L, 0, 0), null);
       assertTrue("The user callback should not be fired.", callbackFired.get() == 0);
     }
-    callback.onCompletion(new RecordMetadata(new TopicPartition("topic", 0), 0L, 0L, 0L, 0, 0, 0), null);
+    callback.onCompletion(new RecordMetadata(new TopicPartition("topic", 0), 0L, 0L, 0L, 0L, 0, 0), null);
     assertTrue("The user callback should not be fired.", callbackFired.get() == 1);
   }
 
@@ -59,10 +59,10 @@ public class LageMessageCallbackTest {
       if (i == 3) {
         e = e1;
       }
-      callback.onCompletion(new RecordMetadata(new TopicPartition("topic", 0), 0L, 0L, 0L, 0, 0, 0), e);
+      callback.onCompletion(new RecordMetadata(new TopicPartition("topic", 0), 0L, 0L, 0L, 0L, 0, 0), e);
       assertTrue("The user callback should not be fired.", callbackFired.get() == 0);
     }
-    callback.onCompletion(new RecordMetadata(new TopicPartition("topic", 0), 0L, 0L, 0L, 0, 0, 0), e2);
+    callback.onCompletion(new RecordMetadata(new TopicPartition("topic", 0), 0L, 0L, 0L, 0L, 0, 0), e2);
     assertTrue("The user callback should not be fired.", callbackFired.get() == 1);
   }
 }


### PR DESCRIPTION
The following changes have been made in addition to bumping up the Kafka version to pull in:
- LiKafkaConsumerImpl implements new methods in the KafkaConsumer API, including ones that introduce timeouts for existing operations like position, committed, etc.
- org.apache.kafka.common.protocol.Security is under the package, org.apache.kafka.common.security.auth, in 2.0
- Redundant API declarations in LiKafkaProducer and LiKafkaConsumer have been removed.

