### PR TITLE
Make topic name accessible in the MessageSplitterImpl

### DIFF
--- a/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/largemessage/MessageSplitterImpl.java
+++ b/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/largemessage/MessageSplitterImpl.java
@@ -94,8 +94,8 @@ public class MessageSplitterImpl implements MessageSplitter {
       LargeMessageSegment segment = new LargeMessageSegment(segmentMessageId, seq,
           numberOfSegments, messageSizeInBytes, payload);
 
-      // NOTE: we have to use null topic here to serialize because the segment should be topic independent.
-      byte[] segmentValue = _segmentSerializer.serialize(null, segment);
+      // NOTE: Even though we are passing topic here to serialize, the segment itself should be topic independent.
+      byte[] segmentValue = _segmentSerializer.serialize(topic, segment);
       ProducerRecord<byte[], byte[]> segmentProducerRecord =
           new ProducerRecord<>(topic, partition, timestamp, segmentKey, segmentValue);
       segments.add(segmentProducerRecord);


### PR DESCRIPTION
Even though we are passing topic here to serialize method, the segment itself should be topic independent. This fix was missed when porting all changes from Linkedin. 