### PR TITLE
Various improvements to LiKafkaProducerImpl.

### DIFF
--- a/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/producer/LiKafkaProducerConfig.java
+++ b/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/producer/LiKafkaProducerConfig.java
@@ -90,7 +90,7 @@ public class LiKafkaProducerConfig extends AbstractConfig {
         .define(CLUSTER_GROUP_CONFIG, Type.STRING, "", Importance.MEDIUM, CLUSTER_GROUP_DOC)
         .define(CLUSTER_ENVIRONMENT_CONFIG, Type.STRING, "", Importance.MEDIUM, CLUSTER_ENVIRONMENT_DOC)
         .define(MAX_REQUEST_SIZE_CONFIG, Type.INT, 1 * 1024 * 1024, atLeast(0), Importance.MEDIUM, MAX_REQUEST_SIZE_DOC)
-        .define(LARGE_MESSAGE_SEGMENT_WRAPPING_REQUIRED_CONFIG, Type.BOOLEAN, "false", Importance.MEDIUM,
+        .define(LARGE_MESSAGE_SEGMENT_WRAPPING_REQUIRED_CONFIG, Type.BOOLEAN, "true", Importance.MEDIUM,
             LARGE_MESSAGE_SEGMENT_WRAPPING_REQUIRED_DOC);
   }
 


### PR DESCRIPTION
1. Use LongAdder instead of AtomicInteger, which is more performant.
2. Use the large.message.segment.wrapping.required property to control whether or not wrap a normal-sized message in a large message segment
  (The default value is set to false for now, to match the previous behavior.)
3. Use the min of max.message.segment.bytes and max.request.size for the max message segment size for large message.
4. Use an exception instead of an assert