### PR TITLE
Federated Clients: implement LiKafkaFederatedConsumerImpl#assign() and assignment()

### DIFF
--- a/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/metadataservice/MetadataServiceClient.java
+++ b/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/metadataservice/MetadataServiceClient.java
@@ -7,10 +7,12 @@ package com.linkedin.kafka.clients.metadataservice;
 import com.linkedin.kafka.clients.common.ClusterDescriptor;
 import com.linkedin.kafka.clients.common.ClusterGroupDescriptor;
 
+import java.util.Collection;
 import java.util.Map;
 import java.util.UUID;
 
 import org.apache.kafka.common.Configurable;
+import org.apache.kafka.common.TopicPartition;
 
 
 // An interface to a generic metadata service which serves cluster and topic metadata for federated Kafka clusters.
@@ -26,14 +28,25 @@ public interface MetadataServiceClient extends Configurable, AutoCloseable {
   public UUID registerFederatedClient(ClusterGroupDescriptor clusterGroup, Map<String, ?> configs, int timeoutMs);
 
   /**
-   * Get the cluster name for the given topic from the given cluster group.
+   * Get the cluster name for the given topic.
    *
    * @param clientId   The id of the client
    * @param topicName  The topic name
-   * @param timeoutMs     Timeout in milliseconds
+   * @param timeoutMs  Timeout in milliseconds
    * @return The descriptor of the physical cluster where the topic is hosted
    */
   public ClusterDescriptor getClusterForTopic(UUID clientId, String topicName, int timeoutMs);
+
+  /**
+   * Get a map from the given topic partitions to the clusters where they are hosted.
+   *
+   * @param clientId         The id of the client
+   * @param topicPartitions  The topic partitions
+   * @param timeoutMs        Timeout in milliseconds
+   * @return A map from topic partitions to the descriptors of the physical clusters where they are hosted
+   */
+  public Map<TopicPartition, ClusterDescriptor> getClustersForTopicPartitions(UUID clientId,
+      Collection<TopicPartition> topicPartitions, int timeoutMs);
 
   /**
    * Close this metadata service client with the specified timeout.

--- a/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/metadataservice/MetadataServiceClient.java
+++ b/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/metadataservice/MetadataServiceClient.java
@@ -28,7 +28,7 @@ public interface MetadataServiceClient extends Configurable, AutoCloseable {
   public UUID registerFederatedClient(ClusterGroupDescriptor clusterGroup, Map<String, ?> configs, int timeoutMs);
 
   /**
-   * Get the cluster name for the given topic.
+   * Get the cluster name for the given topic. If the topic does not exist in this group, return null.
    *
    * @param clientId   The id of the client
    * @param topicName  The topic name
@@ -38,7 +38,8 @@ public interface MetadataServiceClient extends Configurable, AutoCloseable {
   public ClusterDescriptor getClusterForTopic(UUID clientId, String topicName, int timeoutMs);
 
   /**
-   * Get a map from the given topic partitions to the clusters where they are hosted.
+   * Get a map from the given topic partitions to the clusters where they are hosted. For nonexistent topic partitions,
+   * the cluster will be set to null.
    *
    * @param clientId         The id of the client
    * @param topicPartitions  The topic partitions

--- a/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/producer/LiKafkaFederatedProducerImpl.java
+++ b/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/producer/LiKafkaFederatedProducerImpl.java
@@ -243,7 +243,8 @@ public class LiKafkaFederatedProducerImpl<K, V> implements LiKafkaProducer<K, V>
     throw new UnsupportedOperationException("Not supported");
   }
 
-  public LiKafkaProducer<K, V> getPerClusterProducer(ClusterDescriptor cluster) {
+  // Intended for testing only
+  LiKafkaProducer<K, V> getPerClusterProducer(ClusterDescriptor cluster) {
     return _producers.get(cluster);
   }
 

--- a/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/producer/LiKafkaFederatedProducerImpl.java
+++ b/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/producer/LiKafkaFederatedProducerImpl.java
@@ -249,10 +249,23 @@ public class LiKafkaFederatedProducerImpl<K, V> implements LiKafkaProducer<K, V>
   }
 
   private LiKafkaProducer<K, V> getOrCreateProducerForTopic(String topic) {
-    return getOrCreatePerClusterProducer(_mdsClient.getClusterForTopic(_clientId, topic, _mdsRequestTimeoutMs));
+    if (topic == null || topic.isEmpty()) {
+      throw new IllegalArgumentException("Topic cannot be null or empty");
+    }
+
+    // TODO: Handle nonexistent topics more elegantly with auto topic creation option
+    ClusterDescriptor cluster = _mdsClient.getClusterForTopic(_clientId, topic, _mdsRequestTimeoutMs);
+    if (cluster == null) {
+      throw new IllegalStateException("Topic " + topic + " not found in the metadata service");
+    }
+    return getOrCreatePerClusterProducer(cluster);
   }
 
   private LiKafkaProducer<K, V> getOrCreatePerClusterProducer(ClusterDescriptor cluster) {
+    if (cluster == null) {
+      throw new IllegalArgumentException("Cluster cannot be null");
+    }
+
     if (_producers.containsKey(cluster)) {
       return _producers.get(cluster);
     }

--- a/li-apache-kafka-clients/src/test/java/com/linkedin/kafka/clients/consumer/LiKafkaFederatedConsumerImplTest.java
+++ b/li-apache-kafka-clients/src/test/java/com/linkedin/kafka/clients/consumer/LiKafkaFederatedConsumerImplTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2019 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License").  See License in the project root for license information.
+ */
+
+package com.linkedin.kafka.clients.consumer;
+
+import com.linkedin.kafka.clients.common.ClusterDescriptor;
+import com.linkedin.kafka.clients.metadataservice.MetadataServiceClient;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.Future;
+
+import org.apache.kafka.clients.consumer.MockConsumer;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.OffsetResetStrategy;
+import org.apache.kafka.common.TopicPartition;
+import org.mockito.Mockito;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.*;
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertNotNull;
+import static org.testng.AssertJUnit.assertNull;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * The unit test for federated consumer.
+ */
+public class LiKafkaFederatedConsumerImplTest {
+  private static final Logger LOG = LoggerFactory.getLogger(LiKafkaFederatedConsumerImplTest.class);
+
+  private static final UUID CLIENT_ID = new UUID(0, 0);
+  private static final String TOPIC1 = "topic1";
+  private static final String TOPIC2 = "topic2";
+  private static final String TOPIC3 = "topic3";
+  private static final TopicPartition TOPIC_PARTITION1 = new TopicPartition(TOPIC1, 0);
+  private static final TopicPartition TOPIC_PARTITION2 = new TopicPartition(TOPIC2, 0);
+  private static final TopicPartition TOPIC_PARTITION3 = new TopicPartition(TOPIC3, 0);
+  private static final ClusterDescriptor CLUSTER1 = new ClusterDescriptor("cluster1", "url1", "zk1");
+  private static final ClusterDescriptor CLUSTER2 = new ClusterDescriptor("cluster2", "url2", "zk2");
+
+  private MetadataServiceClient _mdsClient;
+  private LiKafkaFederatedConsumerImpl<byte[], byte[]> _federatedConsumer;
+
+  private class MockConsumerBuilder extends LiKafkaConsumerBuilder<byte[], byte[]> {
+    OffsetResetStrategy _offsetResetStrategy = OffsetResetStrategy.EARLIEST;
+
+    public MockConsumerBuilder setOffsetResetStrategy(OffsetResetStrategy offsetResetStrategy) {
+      _offsetResetStrategy = offsetResetStrategy;
+      return this;
+    }
+
+    @Override
+    public LiKafkaConsumer<byte[], byte[]> build() {
+      return new MockLiKafkaConsumer(_offsetResetStrategy);
+    }
+  }
+
+  @BeforeMethod
+  public void setup() {
+    _mdsClient = Mockito.mock(MetadataServiceClient.class);
+    when(_mdsClient.registerFederatedClient(anyObject(), anyObject(), anyInt())).thenReturn(CLIENT_ID);
+
+    Map<String, String> consumerConfig = new HashMap<>();
+    consumerConfig.put(LiKafkaConsumerConfig.CLUSTER_ENVIRONMENT_CONFIG, "env");
+    consumerConfig.put(LiKafkaConsumerConfig.CLUSTER_GROUP_CONFIG, "group");
+    consumerConfig.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.ByteArrayDeserializer");
+    consumerConfig.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.ByteArrayDeserializer");
+
+    _federatedConsumer = new LiKafkaFederatedConsumerImpl<>(consumerConfig, _mdsClient, new MockConsumerBuilder());
+  }
+
+  @Test
+  public void testBasicWorkflow() {
+    // Set expectations so that topics 1 and 3 are hosted in cluster 1 and topic 2 in cluster 2.
+    Collection<TopicPartition> expectedTopicPartitions = Arrays.asList(TOPIC_PARTITION1, TOPIC_PARTITION2,
+        TOPIC_PARTITION3);
+    Map<TopicPartition, ClusterDescriptor> topicPartitionsToClusterMapToReturn =
+        new HashMap<TopicPartition, ClusterDescriptor>() {{
+          put(TOPIC_PARTITION1, CLUSTER1);
+          put(TOPIC_PARTITION2, CLUSTER2);
+          put(TOPIC_PARTITION3, CLUSTER1);
+    }};
+    when(_mdsClient.getClustersForTopicPartitions(eq(CLIENT_ID), eq(expectedTopicPartitions), anyInt()))
+        .thenReturn(topicPartitionsToClusterMapToReturn);
+
+    // Make sure we start with a clean slate
+    assertNull("Consumer for cluster 1 should have not been created yet",
+        _federatedConsumer.getPerClusterConsumer(CLUSTER1));
+    assertNull("Consumer for cluster 2 should have not been created yet",
+        _federatedConsumer.getPerClusterConsumer(CLUSTER2));
+
+    // Assign topic partitions from all three topics
+    _federatedConsumer.assign(Arrays.asList(TOPIC_PARTITION1, TOPIC_PARTITION2, TOPIC_PARTITION3));
+
+    // Verify consumers for both clusters have been created.
+    MockConsumer consumer1 = ((MockLiKafkaConsumer) _federatedConsumer.getPerClusterConsumer(CLUSTER1)).getDelegate();
+    MockConsumer consumer2 = ((MockLiKafkaConsumer) _federatedConsumer.getPerClusterConsumer(CLUSTER2)).getDelegate();
+    assertNotNull("Consumer for cluster 1 should have been created", consumer1);
+    assertNotNull("Consumer for cluster 2 should have been created", consumer2);
+
+    // Verify if assignment() returns all topic partitions.
+    assertEquals("assignment() should return all topic partitions",
+        new HashSet<TopicPartition>(expectedTopicPartitions), _federatedConsumer.assignment());
+  }
+
+  private boolean isError(Future<?> future) {
+    try {
+      future.get();
+      return false;
+    } catch (Exception e) {
+      return true;
+    }
+  }
+}

--- a/li-apache-kafka-clients/src/test/java/com/linkedin/kafka/clients/consumer/MockLiKafkaConsumer.java
+++ b/li-apache-kafka-clients/src/test/java/com/linkedin/kafka/clients/consumer/MockLiKafkaConsumer.java
@@ -1,0 +1,274 @@
+/*
+ * Copyright 2019 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License").  See License in the project root for license information.
+ */
+
+package com.linkedin.kafka.clients.consumer;
+
+import java.time.Duration;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
+
+import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.MockConsumer;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.clients.consumer.OffsetAndTimestamp;
+import org.apache.kafka.clients.consumer.OffsetCommitCallback;
+import org.apache.kafka.clients.consumer.OffsetResetStrategy;
+import org.apache.kafka.common.Metric;
+import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.PartitionInfo;
+import org.apache.kafka.common.TopicPartition;
+
+
+// Mock LiKafkaConsumer with raw byte key and value
+public class MockLiKafkaConsumer implements LiKafkaConsumer<byte[], byte[]> {
+  private MockConsumer<byte[], byte[]> _delegate;
+
+  public MockLiKafkaConsumer(OffsetResetStrategy offsetResetStrategy) {
+    _delegate = new MockConsumer<>(offsetResetStrategy);
+  }
+
+  @Override
+  public Set<TopicPartition> assignment() {
+    return _delegate.assignment();
+  }
+
+  @Override
+  public Set<String> subscription() {
+    return _delegate.subscription();
+  }
+
+  @Override
+  public void subscribe(Collection<String> topics) {
+    _delegate.subscribe(topics);
+  }
+
+  @Override
+  public void subscribe(Collection<String> topics, ConsumerRebalanceListener callback) {
+    _delegate.subscribe(topics, callback);
+  }
+
+  @Override
+  public void assign(Collection<TopicPartition> partitions) {
+    _delegate.assign(partitions);
+  }
+
+  @Override
+  public void subscribe(Pattern pattern, ConsumerRebalanceListener callback) {
+    _delegate.subscribe(pattern, callback);
+  }
+
+  @Override
+  public void subscribe(Pattern pattern) {
+    _delegate.subscribe(pattern);
+  }
+
+  @Override
+  public void unsubscribe() {
+    _delegate.unsubscribe();
+  }
+
+  @Override
+  public ConsumerRecords<byte[], byte[]> poll(long timeout) {
+    return _delegate.poll(timeout);
+  }
+
+  @Override
+  public ConsumerRecords<byte[], byte[]> poll(Duration timeout) {
+    return _delegate.poll(timeout);
+  }
+
+  @Override
+  public void commitSync() {
+    _delegate.commitSync();
+  }
+
+  @Override
+  public void commitSync(Duration timeout) {
+    _delegate.commitSync(timeout);
+  }
+
+  @Override
+  public void commitSync(Map<TopicPartition, OffsetAndMetadata> offsets) {
+    _delegate.commitSync(offsets);
+  }
+
+  @Override
+  public void commitSync(Map<TopicPartition, OffsetAndMetadata> offsets, Duration timeout) {
+    _delegate.commitSync(offsets, timeout);
+  }
+
+  @Override
+  public void commitAsync() {
+    _delegate.commitAsync();
+  }
+
+  @Override
+  public void commitAsync(OffsetCommitCallback callback) {
+    _delegate.commitAsync(callback);
+  }
+
+  @Override
+  public void commitAsync(Map<TopicPartition, OffsetAndMetadata> offsets, OffsetCommitCallback callback) {
+    _delegate.commitAsync(offsets, callback);
+  }
+
+  @Override
+  public void seek(TopicPartition partition, long offset) {
+    _delegate.seek(partition, offset);
+  }
+
+  @Override
+  public void seekToBeginning(Collection<TopicPartition> partitions) {
+    _delegate.seekToBeginning(partitions);
+  }
+
+  @Override
+  public void seekToEnd(Collection<TopicPartition> partitions) {
+    _delegate.seekToEnd(partitions);
+  }
+
+  @Override
+  public void seekToCommitted(Collection<TopicPartition> partitions) {
+    throw new UnsupportedOperationException("Not implemented yet");
+  }
+
+  @Override
+  public long position(TopicPartition partition) {
+    return _delegate.position(partition);
+  }
+
+  @Override
+  public long position(TopicPartition partition, Duration timeout) {
+    return _delegate.position(partition, timeout);
+  }
+
+  @Override
+  public OffsetAndMetadata committed(TopicPartition partition) {
+    return _delegate.committed(partition);
+  }
+
+  @Override
+  public OffsetAndMetadata committed(TopicPartition partition, Duration timeout) {
+    return _delegate.committed(partition, timeout);
+  }
+
+  @Override
+  public Long committedSafeOffset(TopicPartition tp) {
+    throw new UnsupportedOperationException("Not implemented yet");
+  }
+
+  @Override
+  public Map<MetricName, ? extends Metric> metrics() {
+    return _delegate.metrics();
+  }
+
+  @Override
+  public List<PartitionInfo> partitionsFor(String topic) {
+    return _delegate.partitionsFor(topic);
+  }
+
+  @Override
+  public List<PartitionInfo> partitionsFor(String topic, Duration timeout) {
+    return _delegate.partitionsFor(topic, timeout);
+  }
+
+  @Override
+  public Map<String, List<PartitionInfo>> listTopics() {
+    return _delegate.listTopics();
+  }
+
+  @Override
+  public Map<String, List<PartitionInfo>> listTopics(Duration timeout) {
+    return _delegate.listTopics(timeout);
+  }
+
+  @Override
+  public Set<TopicPartition> paused() {
+    return _delegate.paused();
+  }
+
+  @Override
+  public void pause(Collection<TopicPartition> partitions) {
+    _delegate.pause(partitions);
+  }
+
+  @Override
+  public void resume(Collection<TopicPartition> partitions) {
+    _delegate.resume(partitions);
+  }
+
+  @Override
+  public Map<TopicPartition, OffsetAndTimestamp> offsetsForTimes(Map<TopicPartition, Long> timestampsToSearch) {
+    return _delegate.offsetsForTimes(timestampsToSearch);
+  }
+
+  @Override
+  public Map<TopicPartition, OffsetAndTimestamp> offsetsForTimes(Map<TopicPartition, Long> timestampsToSearch, Duration timeout) {
+    return _delegate.offsetsForTimes(timestampsToSearch, timeout);
+  }
+
+  @Override
+  public Map<TopicPartition, Long> beginningOffsets(Collection<TopicPartition> partitions) {
+    return _delegate.beginningOffsets(partitions);
+  }
+
+  @Override
+  public Map<TopicPartition, Long> beginningOffsets(Collection<TopicPartition> partitions, Duration timeout) {
+    return _delegate.beginningOffsets(partitions, timeout);
+  }
+
+  @Override
+  public Map<TopicPartition, Long> endOffsets(Collection<TopicPartition> partitions) {
+    return _delegate.endOffsets(partitions);
+  }
+
+  @Override
+  public Map<TopicPartition, Long> endOffsets(Collection<TopicPartition> partitions, Duration timeout) {
+    return _delegate.endOffsets(partitions, timeout);
+  }
+
+  @Override
+  public Long safeOffset(TopicPartition tp, long messageOffset) {
+    throw new UnsupportedOperationException("Not implemented yet");
+  }
+
+  @Override
+  public Long safeOffset(TopicPartition tp) {
+    throw new UnsupportedOperationException("Not implemented yet");
+  }
+
+  @Override
+  public Map<TopicPartition, Long> safeOffsets() {
+    throw new UnsupportedOperationException("Not implemented yet");
+  }
+
+  @Override
+  public void close() {
+    _delegate.close();
+  }
+
+  @Override
+  public void close(long timeout, TimeUnit timeUnit) {
+    _delegate.close(timeout, timeUnit);
+  }
+
+  @Override
+  public void close(Duration timeout) {
+    _delegate.close(timeout);
+  }
+
+  @Override
+  public void wakeup() {
+    _delegate.wakeup();
+  }
+
+  public MockConsumer<byte[], byte[]> getDelegate() {
+    return _delegate;
+  }
+}


### PR DESCRIPTION
Also removed an unused class from LiKafkaFederatedProducerImpl.java.