### PR TITLE
fix message loss between poll() and close()

### DIFF
--- a/integration-tests/src/test/java/com/linkedin/kafka/clients/consumer/LiKafkaConsumerIntegrationTest.java
+++ b/integration-tests/src/test/java/com/linkedin/kafka/clients/consumer/LiKafkaConsumerIntegrationTest.java
@@ -980,11 +980,11 @@ public class LiKafkaConsumerIntegrationTest extends AbstractKafkaClientsIntegrat
     props.setProperty(ConsumerConfig.GROUP_ID_CONFIG, "testCommit");
     // Make sure we start to consume from the beginning.
     props.setProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+    props.setProperty(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false");
 
     return new LiKafkaConsumerImpl<>(getConsumerProperties(props),
         new ByteArrayDeserializer(),
         new Deserializer<byte[]>() {
-          int numMessages = 0;
           @Override
           public void configure(Map<String, ?> configs, boolean isKey) {
 
@@ -992,9 +992,8 @@ public class LiKafkaConsumerIntegrationTest extends AbstractKafkaClientsIntegrat
 
           @Override
           public byte[] deserialize(String topic, byte[] data) {
-            // Throw exception when deserializing the second message.
-            numMessages++;
-            if (numMessages == 2) {
+            // Throw exception when deserializing
+            if (new String(data).startsWith(KafkaTestUtils.EXCEPTION_MESSAGE)) {
               throw new SerializationException();
             }
             return data;
@@ -1013,94 +1012,93 @@ public class LiKafkaConsumerIntegrationTest extends AbstractKafkaClientsIntegrat
       consumer.subscribe(Collections.singleton(topic));
       ConsumerRecords<byte[], byte[]> records = ConsumerRecords.empty();
       while (records.isEmpty()) {
-        records = consumer.poll(1000);
+        records = consumer.poll(Duration.ofMillis(1000));
       }
-      assertEquals(records.count(), 1, "Only the first message should be returned");
+      assertEquals(records.count(), 4, "Only the first message should be returned");
       assertEquals(records.iterator().next().offset(), 2L, "The offset of the first message should be 2.");
-      assertEquals(consumer.position(new TopicPartition(topic, 0)), 4L, "The position should be 4");
+      assertEquals(consumer.position(new TopicPartition(topic, 0)), 7L, "The position should be 7");
 
       testFunction.accept(consumer, new TopicPartition(topic, 0));
-      assertEquals(consumer.position(new TopicPartition(topic, 0)), 5L, "The position should be 5");
-
-      records = ConsumerRecords.empty();
-      while (records.isEmpty()) {
-        records = consumer.poll(1000);
-      }
-      assertEquals(records.count(), 4, "There should be four messages left.");
-      assertEquals(records.iterator().next().offset(), 5L, "The first offset should 5");
     } finally {
       consumer.close();
     }
   }
 
   @Test
-  public void testExceptionProcessing() {
+  public void testExceptionHandlingAndProcessing() {
     List<BiConsumer<LiKafkaConsumer<byte[], byte[]>, TopicPartition>> testFuncList = new ArrayList<>(6);
     testFuncList.add((consumer, tp) -> {
       try {
-        consumer.poll(1000);
+        consumer.poll(Duration.ofMillis(1000));
         fail("Should have thrown exception.");
       } catch (ConsumerRecordsProcessingException crpe) {
         // expected
-      } catch (Exception e) {
-        fail("Unexpected exception");
       }
+
+      assertEquals(consumer.position(tp), 8L, "The position should be 8");
+      ConsumerRecords<byte[], byte[]> records = ConsumerRecords.empty();
+      while (records.isEmpty()) {
+        records = consumer.poll(1000);
+      }
+      assertEquals(records.count(), 1, "There should be four messages left.");
     });
 
     testFuncList.add((consumer, tp) -> {
+      consumer.pause(Collections.singleton(tp));
+      consumer.poll(Duration.ofMillis(1000));
+      consumer.resume(Collections.singleton(tp));
+      assertEquals(consumer.position(tp), 7L, "The position should be 7");
+
+      ConsumerRecords<byte[], byte[]> records = ConsumerRecords.empty();
       try {
-        consumer.seek(tp, 0);
-        fail("Should have thrown exception.");
-      } catch (IllegalStateException e) {
+        while (records.isEmpty()) {
+          records = consumer.poll(Duration.ofMillis(1000));
+        }
+      } catch (ConsumerRecordsProcessingException crpe) {
         // expected
-      } catch (Exception e) {
-        fail("Unexpected exception");
       }
+      assertEquals(consumer.position(tp), 8L, "The position should be 8");
     });
 
     testFuncList.add((consumer, tp) -> {
+      consumer.seek(tp, 6);
       try {
-        consumer.seekToCommitted(Collections.singleton(tp));
-        fail("Should have thrown exception.");
-      } catch (IllegalStateException e) {
-        // expected
+        consumer.poll(Duration.ofMillis(1000));
       } catch (Exception e) {
         fail("Unexpected exception");
       }
+      assertEquals(consumer.position(tp), 7L, "The position should be 7");
     });
 
     testFuncList.add((consumer, tp) -> {
+      consumer.commitSync(Collections.singletonMap(tp, new OffsetAndMetadata(4L)));
+      consumer.seekToCommitted(Collections.singleton(tp));
       try {
-        consumer.seekToBeginning(Collections.singleton(tp));
-        fail("Should have thrown exception.");
-      } catch (IllegalStateException e) {
-        // expected
+        consumer.poll(Duration.ofMillis(1000));
       } catch (Exception e) {
         fail("Unexpected exception");
       }
+      assertEquals(consumer.position(tp), 7L, "The position should be 7");
     });
 
     testFuncList.add((consumer, tp) -> {
+      consumer.seekToBeginning(Collections.singleton(tp));
       try {
-        consumer.seekToEnd(Collections.singleton(tp));
-        fail("Should have thrown exception.");
-      } catch (IllegalStateException e) {
-        // expected
+        consumer.poll(Duration.ofMillis(1000));
       } catch (Exception e) {
         fail("Unexpected exception");
       }
+      assertEquals(consumer.position(tp), 7L, "The position should be 7");
     });
 
     testFuncList.add((consumer, tp) -> {
+      consumer.seekToEnd(Collections.singleton(tp));
       try {
-        consumer.pause(Collections.singleton(tp));
-        fail("Should have thrown exception.");
-      } catch (IllegalStateException e) {
-        // expected
-        consumer.resume(Collections.singleton(tp));
+        consumer.poll(Duration.ofMillis(1000));
       } catch (Exception e) {
         fail("Unexpected exception");
       }
+      assertEquals(consumer.position(tp), 10L, "The position should be 10");
     });
 
     testFuncList.forEach(
@@ -1115,6 +1113,69 @@ public class LiKafkaConsumerIntegrationTest extends AbstractKafkaClientsIntegrat
           }
         }
     );
+  }
+
+  @Test
+  public void testExceptionInProcessingLargeMessage() {
+    String topic = "testExceptionInProcessing";
+    produceSyntheticMessages(topic);
+    Properties props = new Properties();
+    // All the consumers should have the same group id.
+    props.setProperty(ConsumerConfig.GROUP_ID_CONFIG, "testCommit");
+    // Make sure we start to consume from the beginning.
+    props.setProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+
+    LiKafkaConsumer<byte[], byte[]> consumer =
+        new LiKafkaConsumerImpl<>(getConsumerProperties(props),
+            new ByteArrayDeserializer(),
+            new Deserializer<byte[]>() {
+              int numMessages = 0;
+              @Override
+              public void configure(Map<String, ?> configs, boolean isKey) {
+
+              }
+
+              @Override
+              public byte[] deserialize(String topic, byte[] data) {
+                // Throw exception when deserializing the second message.
+                numMessages++;
+                if (numMessages == 2) {
+                  throw new SerializationException();
+                }
+                return data;
+              }
+
+              @Override
+              public void close() {
+
+              }
+            }, new DefaultSegmentDeserializer(), new NoOpAuditor<>());
+    try {
+      consumer.subscribe(Collections.singleton(topic));
+      ConsumerRecords<byte[], byte[]> records = ConsumerRecords.empty();
+      while (records.isEmpty()) {
+        records = consumer.poll(1000);
+      }
+      assertEquals(records.count(), 1, "Only the first message should be returned");
+      assertEquals(records.iterator().next().offset(), 2L, "The offset of the first message should be 2.");
+      assertEquals(consumer.position(new TopicPartition(topic, 0)), 4L, "The position should be 4");
+
+      try {
+        consumer.poll(1000);
+        fail("Should have thrown exception.");
+      } catch (ConsumerRecordsProcessingException crpe) {
+        // let it go
+      }
+      assertEquals(consumer.position(new TopicPartition(topic, 0)), 5L, "The position should be 5");
+      records = ConsumerRecords.empty();
+      while (records.isEmpty()) {
+        records = consumer.poll(1000);
+      }
+      assertEquals(records.count(), 4, "There should be four messages left.");
+      assertEquals(records.iterator().next().offset(), 5L, "The first offset should 5");
+    } finally {
+      consumer.close();
+    }
   }
 
   @Test
@@ -1226,7 +1287,7 @@ public class LiKafkaConsumerIntegrationTest extends AbstractKafkaClientsIntegrat
     props.setProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
     // Only fetch one record at a time.
     props.setProperty(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, "1");
-    // No auto commmit
+    // No auto commit
     props.setProperty(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false");
     // Not enough memory to assemble anything
     props.setProperty(LiKafkaConsumerConfig.MESSAGE_ASSEMBLER_BUFFER_CAPACITY_CONFIG, "" + (MAX_SEGMENT_SIZE + 1));
@@ -1599,8 +1660,7 @@ public class LiKafkaConsumerIntegrationTest extends AbstractKafkaClientsIntegrat
     List<ProducerRecord<byte[], byte[]>> m3Segs = splitter.split(topic, SYNTHETIC_PARTITION_0, messageId3, message3.getBytes());
     // M4, 1 segment
     UUID messageId4 = LiKafkaClientsUtils.randomUUID();
-    String message4 = KafkaTestUtils.getRandomString(MAX_SEGMENT_SIZE / 2);
-
+    String message4 = KafkaTestUtils.getExceptionString(MAX_SEGMENT_SIZE / 2);
     List<ProducerRecord<byte[], byte[]>> m4Segs = splitter.split(topic, SYNTHETIC_PARTITION_0, messageId4, message4.getBytes());
     // M5, 2 segments
     UUID messageId5 = LiKafkaClientsUtils.randomUUID();

--- a/kafka-test-harness/src/main/java/com/linkedin/kafka/clients/utils/tests/KafkaTestUtils.java
+++ b/kafka-test-harness/src/main/java/com/linkedin/kafka/clients/utils/tests/KafkaTestUtils.java
@@ -22,6 +22,7 @@ public class KafkaTestUtils {
   private final static AtomicBoolean SHUTDOWN_HOOK_INSTALLED = new AtomicBoolean(false);
   private final static Thread SHUTDOWN_HOOK;
   private final static List<File> FILES_TO_CLEAN_UP = Collections.synchronizedList(new ArrayList<>());
+  public final static String EXCEPTION_MESSAGE = "DESERIALIZATION_EXCEPTION_";
 
   static {
     SHUTDOWN_HOOK = new Thread(() -> {
@@ -120,11 +121,21 @@ public class KafkaTestUtils {
   public static String getRandomString(int length) {
     char[] chars = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'};
     Random random = new Random();
-    StringBuilder stringBuiler = new StringBuilder();
+    StringBuilder stringBuilder = new StringBuilder();
     for (int i = 0; i < length; i++) {
-      stringBuiler.append(chars[Math.abs(random.nextInt()) % 16]);
+      stringBuilder.append(chars[Math.abs(random.nextInt()) % 16]);
     }
-    return stringBuiler.toString();
+    return stringBuilder.toString();
+  }
+
+  public static String getExceptionString(int length) {
+    StringBuilder stringBuilder = new StringBuilder();
+    stringBuilder.append(EXCEPTION_MESSAGE);
+    for (int i = EXCEPTION_MESSAGE.length(); i < length; i++) {
+      stringBuilder.append('X');
+    }
+
+    return stringBuilder.toString();
   }
 
   @FunctionalInterface

--- a/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/consumer/LiKafkaConsumerImpl.java
+++ b/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/consumer/LiKafkaConsumerImpl.java
@@ -518,7 +518,7 @@ public class LiKafkaConsumerImpl<K, V> implements LiKafkaConsumer<K, V> {
 
   private void clearRecordProcessingException() {
     if (_lastProcessedResult != null && _lastProcessedResult.hasException()) {
-      LOG.warn("Clearing all Record Processing Exceptions");
+      LOG.warn("Clearing all Record Processing Exceptions", _lastProcessedResult.exception());
       _lastProcessedResult = null;
     }
   }

--- a/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/consumer/LiKafkaConsumerImpl.java
+++ b/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/consumer/LiKafkaConsumerImpl.java
@@ -518,7 +518,7 @@ public class LiKafkaConsumerImpl<K, V> implements LiKafkaConsumer<K, V> {
 
   private void clearRecordProcessingException() {
     if (_lastProcessedResult != null && _lastProcessedResult.hasException()) {
-      LOG.trace("Clearing all Record Processing Exceptions");
+      LOG.warn("Clearing all Record Processing Exceptions");
       _lastProcessedResult = null;
     }
   }

--- a/li-apache-kafka-clients/src/test/java/com/linkedin/kafka/clients/largemessage/ConsumerRecordsProcessorTest.java
+++ b/li-apache-kafka-clients/src/test/java/com/linkedin/kafka/clients/largemessage/ConsumerRecordsProcessorTest.java
@@ -346,8 +346,8 @@ public class ConsumerRecordsProcessorTest {
     assertEquals(result.consumerRecords().records(tp0).size(), 2);
     assertEquals(result.consumerRecords().records(tp1).size(), 1);
     assertEquals(result.consumerRecords().records(tp2).size(), 1);
-    assertTrue(result.resumeOffsets().isEmpty());
-    assertNull(result.exception());
+    assertTrue(result.offsets().isEmpty());
+    assertFalse(result.hasException());
   }
 
   private ConsumerRecords<byte[], byte[]> getConsumerRecords() {


### PR DESCRIPTION
poll() keeps a cache of exceptions per partition and throws exception in subsequent poll() call.
poll() also seek offset past exception assuming next poll() will throw exception.
This can lead to message loss if the user does not call poll() and commits offsets.

The fix stores the current offset and resume offset along with the exception. On exception,
it seeks to current offset (before exception) along with resume offset (current + 1).
On next poll(), poll() will seek to resume offset and throw exception and the user can decide
on either ignoring it which will skip the offset or exit.
On next seek*(), will throw an IllegalStateException and seeking to resume offsets, leaving the
decision to user to continue poll() or crash.
On exit, the user can safely commit offsets it consumed (excluding the offset that hit an exception)
without losing messages.