### PR TITLE
Add federated producer config reload support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,7 @@ project.ext {
     }
   }
   kafkaVersion = "2.0.1"
+  marioVersion = "0.0.6"
 }
 
 subprojects {

--- a/li-apache-kafka-clients/build.gradle
+++ b/li-apache-kafka-clients/build.gradle
@@ -16,6 +16,7 @@ dependencies {
     compile "org.apache.httpcomponents:httpclient:4.5.7"
     compile "org.apache.kafka:kafka-clients:${rootProject.ext.kafkaVersion}"
     compile "com.linkedin.mario:mario-client:0.0.6"
+    compile "com.linkedin.mario:common:0.0.6"
     testCompile "org.mockito:mockito-core:2.24.0"
 }
 

--- a/li-apache-kafka-clients/build.gradle
+++ b/li-apache-kafka-clients/build.gradle
@@ -15,8 +15,8 @@ plugins {
 dependencies {
     compile "org.apache.httpcomponents:httpclient:4.5.7"
     compile "org.apache.kafka:kafka-clients:${rootProject.ext.kafkaVersion}"
-    compile "com.linkedin.mario:mario-client:0.0.6"
-    compile "com.linkedin.mario:common:0.0.6"
+    compile "com.linkedin.mario:mario-client:${rootProject.ext.marioVersion}"
+    compile "com.linkedin.mario:common:${rootProject.ext.marioVersion}"
     testCompile "org.mockito:mockito-core:2.24.0"
 }
 

--- a/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/common/LiKafkaFederatedClient.java
+++ b/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/common/LiKafkaFederatedClient.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright 2019 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License").  See License in the project root for license information.
+ */
+
+package com.linkedin.kafka.clients.common;
+
+
+// A superinterface for LiKafkaFederatedProducerImpl and LiKafkaFederatedConsumerImpl.
+public interface LiKafkaFederatedClient {
+  LiKafkaFederatedClientType getClientType();
+}

--- a/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/common/LiKafkaFederatedClientType.java
+++ b/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/common/LiKafkaFederatedClientType.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright 2019 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License").  See License in the project root for license information.
+ */
+
+package com.linkedin.kafka.clients.common;
+
+
+public enum LiKafkaFederatedClientType {
+  FEDERATED_PRODUCER,
+  FEDERATED_CONSUMER
+}

--- a/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/metadataservice/MarioCommandCallbackImpl.java
+++ b/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/metadataservice/MarioCommandCallbackImpl.java
@@ -38,12 +38,13 @@ class MarioCommandCallbackImpl implements MarioCommandCallback {
         if (_federatedClient.getClientType() == LiKafkaFederatedClientType.FEDERATED_PRODUCER) {
           // Call producer reload config method
           ((LiKafkaFederatedProducerImpl) _federatedClient).reloadConfig(reloadConfigMsg.getConfigs(), reloadConfigMsg.getCommandId());
+        } else {
+          throw new UnsupportedOperationException("Consumer config reload is not supported currently");
         }
         break;
       default:
         // No current support at the moment
-        LOG.warn("command {} is unsupported", marioCommandMessage.getMsgType());
-        break;
+        throw new UnsupportedOperationException("command " + marioCommandMessage.getMsgType() + " is not supported");
     }
   }
 }

--- a/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/metadataservice/MarioCommandCallbackImpl.java
+++ b/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/metadataservice/MarioCommandCallbackImpl.java
@@ -4,14 +4,13 @@
 
 package com.linkedin.kafka.clients.metadataservice;
 
-import com.linkedin.kafka.clients.common.FederatedClientCommandCallback;
-import com.linkedin.kafka.clients.common.FederatedClientCommandType;
+import com.linkedin.kafka.clients.common.LiKafkaFederatedClient;
+import com.linkedin.kafka.clients.common.LiKafkaFederatedClientType;
+import com.linkedin.kafka.clients.producer.LiKafkaFederatedProducerImpl;
 import com.linkedin.mario.common.websockets.MarioCommandCallback;
 import com.linkedin.mario.common.websockets.Messages;
 
-import java.util.Collection;
-import java.util.Map;
-
+import com.linkedin.mario.common.websockets.ReloadConfigRequestMessages;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -22,18 +21,25 @@ import org.slf4j.LoggerFactory;
 class MarioCommandCallbackImpl implements MarioCommandCallback {
   private static final Logger LOG = LoggerFactory.getLogger(MarioCommandCallbackImpl.class);
 
-  private Map<FederatedClientCommandType, FederatedClientCommandCallback> _federatedClientCommandCallbacks;
+  private LiKafkaFederatedClient _federatedClient;
 
-  MarioCommandCallbackImpl(Collection<FederatedClientCommandCallback> callbacks) {
-    for (FederatedClientCommandCallback callback : callbacks) {
-      _federatedClientCommandCallbacks.put(callback.getCommandType(), callback);
-    }
+  MarioCommandCallbackImpl(LiKafkaFederatedClient federatedClient) {
+    _federatedClient = federatedClient;
   }
 
   public void onReceivingCommand(Messages marioCommandMessage) {
     // Find a federate client callback that matches the given Mario command message type and execute it with arguments
     // included in the message.
+
     switch (marioCommandMessage.getMsgType()) {
+      case RELOAD_CONFIG_REQUEST:
+        ReloadConfigRequestMessages reloadConfigMsg = (ReloadConfigRequestMessages) marioCommandMessage;
+
+        if (_federatedClient.getClientType() == LiKafkaFederatedClientType.FEDERATED_PRODUCER) {
+          // Call producer reload config method
+          ((LiKafkaFederatedProducerImpl) _federatedClient).reloadConfig(reloadConfigMsg.getConfigs(), reloadConfigMsg.getCommandId());
+        }
+        break;
       default:
         // No current support at the moment
         LOG.warn("command {} is unsupported", marioCommandMessage.getMsgType());

--- a/li-apache-kafka-clients/src/test/java/com/linkedin/kafka/clients/metadataservice/MarioMetadataServiceClientTest.java
+++ b/li-apache-kafka-clients/src/test/java/com/linkedin/kafka/clients/metadataservice/MarioMetadataServiceClientTest.java
@@ -6,7 +6,7 @@ package com.linkedin.kafka.clients.metadataservice;
 
 import com.linkedin.kafka.clients.common.ClusterDescriptor;
 import com.linkedin.kafka.clients.common.ClusterGroupDescriptor;
-import com.linkedin.kafka.clients.common.FederatedClientCommandCallback;
+import com.linkedin.kafka.clients.common.LiKafkaFederatedClient;
 import com.linkedin.mario.client.MarioClient;
 import com.linkedin.mario.client.models.v1.TopicQuery;
 import com.linkedin.mario.client.util.MarioClusterGroupDescriptor;
@@ -21,7 +21,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
 import org.apache.kafka.common.TopicPartition;
@@ -81,9 +80,8 @@ public class MarioMetadataServiceClientTest {
     configs.put("K1", "V1");
     configs.put("K2", "V2");
 
-    Set<FederatedClientCommandCallback> callbacks = new HashSet<>();
-
-    _marioMetadataServiceClient.registerFederatedClient(CLUSTER_GROUP, configs, callbacks, 100);
+    LiKafkaFederatedClient federatedClient = Mockito.mock(LiKafkaFederatedClient.class);
+    _marioMetadataServiceClient.registerFederatedClient(federatedClient, CLUSTER_GROUP, configs, 100);
 
     // For now, simply verify the corresponding MarioClient method is called once with expected arguments.
     MarioClusterGroupDescriptor expectedMarioClusterGroup = new MarioClusterGroupDescriptor(CLUSTER_GROUP.getName(),

--- a/li-apache-kafka-clients/src/test/java/com/linkedin/kafka/clients/producer/LiKafkaFederatedProducerImplTest.java
+++ b/li-apache-kafka-clients/src/test/java/com/linkedin/kafka/clients/producer/LiKafkaFederatedProducerImplTest.java
@@ -22,6 +22,7 @@ import org.apache.kafka.clients.producer.MockProducer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
+import org.mockito.Matchers;
 import org.mockito.Mockito;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -173,8 +174,8 @@ public class LiKafkaFederatedProducerImplTest {
     _federatedProducer.reloadConfig(newConfigs, commandId);
 
     // verify corresponding marioClient method is only called once
-    verify(_mdsClient, times(1)).reportCommandExecutionComplete(commandId, newConfigs, MsgType.RELOAD_CONFIG_RESPONSE);
-    verify(_mdsClient, times(1)).reRegisterFederatedClient(newConfigs);
+    verify(_mdsClient, times(1)).reportCommandExecutionComplete(eq(commandId), any(), eq(MsgType.RELOAD_CONFIG_RESPONSE));
+    verify(_mdsClient, times(1)).reRegisterFederatedClient(any());
 
     // verify per-cluster producers have been cleared after reloadConfig
     assertNull("Producer for cluster 1 should have been cleared",

--- a/li-apache-kafka-clients/src/test/java/com/linkedin/kafka/clients/producer/LiKafkaFederatedProducerImplTest.java
+++ b/li-apache-kafka-clients/src/test/java/com/linkedin/kafka/clients/producer/LiKafkaFederatedProducerImplTest.java
@@ -22,7 +22,6 @@ import org.apache.kafka.clients.producer.MockProducer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
-import org.mockito.Matchers;
 import org.mockito.Mockito;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;


### PR DESCRIPTION
Add federated producer config reload support, basically flush and close all the per-cluster producers in another thread upon receiving the reload config command.

Currently just use synchronized methods for now, will modify to rwlock later.