### PR TITLE
Add federated consumer reload config support

### DIFF
--- a/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/consumer/LiKafkaFederatedConsumerImpl.java
+++ b/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/consumer/LiKafkaFederatedConsumerImpl.java
@@ -109,8 +109,8 @@ public class LiKafkaFederatedConsumerImpl<K, V> implements LiKafkaConsumer<K, V>
 
   private volatile boolean _closed;
 
-  // Only used for testing
-  private CountDownLatch _latchForTest = new CountDownLatch(1);
+  // Number of config reload operations executed
+  private volatile int _numConfigReloads;
 
   public LiKafkaFederatedConsumerImpl(Properties props) {
     this(new LiKafkaConsumerConfig(props), null, null);
@@ -154,6 +154,7 @@ public class LiKafkaFederatedConsumerImpl<K, V> implements LiKafkaConsumer<K, V>
     _clientIdPrefix = clientIdPrefix;
 
     _closed = false;
+    _numConfigReloads = 0;
 
     try {
       // Instantiate metadata service client if necessary.
@@ -601,7 +602,7 @@ public class LiKafkaFederatedConsumerImpl<K, V> implements LiKafkaConsumer<K, V>
     t.setName("LiKafkaConsumer-reloadConfig-" + _clusterGroup.getName());
     t.setUncaughtExceptionHandler(new Thread.UncaughtExceptionHandler() {
       public void uncaughtException(Thread t, Throwable e) {
-        throw new KafkaException("Thread " + t.getName() + " throws exception", e);
+        LOG.error("Thread {} throws exception {}", t.getName(), e);
       }
     });
 
@@ -638,14 +639,17 @@ public class LiKafkaFederatedConsumerImpl<K, V> implements LiKafkaConsumer<K, V>
     // re-register federated client with updated configs
     _mdsClient.reRegisterFederatedClient(newConfigs);
 
-    _latchForTest.countDown();
+    _numConfigReloads++;
 
     LOG.info("Successfully updated LiKafkaConsumers configs in clusterGroup {} with new configs (diff) {}", _clusterGroup, newConfigs);
   }
 
   // For testing only, wait for reload config command to finish since it's being executed by a different thread
   void waitForReloadConfigFinish() throws InterruptedException {
-    _latchForTest.await(1, TimeUnit.MINUTES);
+    long endWaitTime = System.currentTimeMillis() + Duration.ofMinutes(1).toMillis();
+    while (_numConfigReloads == 0 && System.currentTimeMillis() < endWaitTime) {
+      TimeUnit.MILLISECONDS.sleep(200);
+    }
   }
 
   // Intended for testing only

--- a/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/consumer/LiKafkaFederatedConsumerImpl.java
+++ b/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/consumer/LiKafkaFederatedConsumerImpl.java
@@ -11,8 +11,8 @@ import com.linkedin.kafka.clients.common.LiKafkaFederatedClientType;
 import com.linkedin.kafka.clients.metadataservice.MetadataServiceClient;
 import com.linkedin.kafka.clients.metadataservice.MetadataServiceClientException;
 import com.linkedin.kafka.clients.utils.LiKafkaClientsUtils;
-
 import com.linkedin.mario.common.websockets.MsgType;
+
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -610,6 +610,9 @@ public class LiKafkaFederatedConsumerImpl<K, V> implements LiKafkaConsumer<K, V>
 
   // Do synchronization on the method that will be closing the consumers since it will be handled by a different thread
   synchronized void closeExistingConsumers(Map<String, String> newConfigs, UUID commandId) {
+    // TODO: ensureOpen() would throw an exception if consumers are already closed. In this case, we might want to send
+    // an error message to notify mario that the config reload command fails due to consumer/producer already closed and
+    // let mario decide what to do next (re-send the configs etc).
     ensureOpen();
 
     closeNoLock(RELOAD_CONFIG_EXECUTION_TIME_OUT.toMillis(), TimeUnit.MILLISECONDS);
@@ -637,7 +640,7 @@ public class LiKafkaFederatedConsumerImpl<K, V> implements LiKafkaConsumer<K, V>
 
     _latchForTest.countDown();
 
-    LOG.info("Successfully restarted LiKafkaConsumers in clusterGroup {} with new configs (diff) {}", _clusterGroup, newConfigs);
+    LOG.info("Successfully updated LiKafkaConsumers configs in clusterGroup {} with new configs (diff) {}", _clusterGroup, newConfigs);
   }
 
   // For testing only, wait for reload config command to finish since it's being executed by a different thread

--- a/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/metadataservice/MarioCommandCallbackImpl.java
+++ b/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/metadataservice/MarioCommandCallbackImpl.java
@@ -6,6 +6,7 @@ package com.linkedin.kafka.clients.metadataservice;
 
 import com.linkedin.kafka.clients.common.LiKafkaFederatedClient;
 import com.linkedin.kafka.clients.common.LiKafkaFederatedClientType;
+import com.linkedin.kafka.clients.consumer.LiKafkaFederatedConsumerImpl;
 import com.linkedin.kafka.clients.producer.LiKafkaFederatedProducerImpl;
 import com.linkedin.mario.common.websockets.MarioCommandCallback;
 import com.linkedin.mario.common.websockets.Messages;
@@ -39,7 +40,8 @@ class MarioCommandCallbackImpl implements MarioCommandCallback {
           // Call producer reload config method
           ((LiKafkaFederatedProducerImpl) _federatedClient).reloadConfig(reloadConfigMsg.getConfigs(), reloadConfigMsg.getCommandId());
         } else {
-          throw new UnsupportedOperationException("Consumer config reload is not supported currently");
+          // call consumer reload config method
+          ((LiKafkaFederatedConsumerImpl) _federatedClient).reloadConfig(reloadConfigMsg.getConfigs(), reloadConfigMsg.getCommandId());
         }
         break;
       default:

--- a/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/producer/LiKafkaFederatedProducerImpl.java
+++ b/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/producer/LiKafkaFederatedProducerImpl.java
@@ -80,8 +80,8 @@ public class LiKafkaFederatedProducerImpl<K, V> implements LiKafkaProducer<K, V>
 
   private volatile boolean _closed;
 
-  // Only used for testing
-  private CountDownLatch _latchForTest = new CountDownLatch(1);
+  // Number of config reload operations executed
+  private volatile int _numConfigReloads;
 
   public LiKafkaFederatedProducerImpl(Properties props) {
     this(new LiKafkaProducerConfig(props), null, null);
@@ -122,6 +122,7 @@ public class LiKafkaFederatedProducerImpl<K, V> implements LiKafkaProducer<K, V>
     _clientIdPrefix = clientIdPrefix;
 
     _closed = false;
+    _numConfigReloads = 0;
 
     try {
       // Instantiate metadata service client if necessary.
@@ -344,7 +345,7 @@ public class LiKafkaFederatedProducerImpl<K, V> implements LiKafkaProducer<K, V>
     t.setName("LiKafkaProducer-reloadConfig-" + _clusterGroup.getName());
     t.setUncaughtExceptionHandler(new Thread.UncaughtExceptionHandler() {
       public void uncaughtException(Thread t, Throwable e) {
-        throw new KafkaException("Thread " + t.getName() + " throws exception", e);
+        LOG.error("Thread {} throws exception {}", t.getName(), e);
       }
     });
 
@@ -379,14 +380,17 @@ public class LiKafkaFederatedProducerImpl<K, V> implements LiKafkaProducer<K, V>
     // re-register federated client with updated configs
     _mdsClient.reRegisterFederatedClient(newConfigs);
 
-    _latchForTest.countDown();
+    _numConfigReloads++;
 
     LOG.info("Successfully updated LiKafkaProducers configs in clusterGroup {} with new configs (diff) {}", _clusterGroup, newConfigs);
   }
 
   // For testing only, wait for reload config command to finish since it's being executed by a different thread
   void waitForReloadConfigFinish() throws InterruptedException {
-    _latchForTest.await(1, TimeUnit.MINUTES);
+    long endWaitTime = System.currentTimeMillis() + Duration.ofMinutes(1).toMillis();
+    while (_numConfigReloads == 0 && System.currentTimeMillis() < endWaitTime) {
+      TimeUnit.MILLISECONDS.sleep(200);
+    }
   }
 
   // Intended for testing only

--- a/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/producer/LiKafkaFederatedProducerImpl.java
+++ b/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/producer/LiKafkaFederatedProducerImpl.java
@@ -80,6 +80,9 @@ public class LiKafkaFederatedProducerImpl<K, V> implements LiKafkaProducer<K, V>
 
   private volatile boolean _closed;
 
+  // Only used for testing
+  private CountDownLatch _latchForTest = new CountDownLatch(1);
+
   public LiKafkaFederatedProducerImpl(Properties props) {
     this(new LiKafkaProducerConfig(props), null, null);
   }
@@ -376,7 +379,14 @@ public class LiKafkaFederatedProducerImpl<K, V> implements LiKafkaProducer<K, V>
     // re-register federated client with updated configs
     _mdsClient.reRegisterFederatedClient(newConfigs);
 
+    _latchForTest.countDown();
+
     LOG.info("Successfully restarted LiKafkaProducers in clusterGroup {} with new configs (diff) {}", _clusterGroup, newConfigs);
+  }
+
+  // For testing only, wait for reload config command to finish since it's being executed by a different thread
+  void waitForReloadConfigFinish() throws InterruptedException {
+    _latchForTest.await(1, TimeUnit.MINUTES);
   }
 
   // Intended for testing only

--- a/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/producer/LiKafkaFederatedProducerImpl.java
+++ b/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/producer/LiKafkaFederatedProducerImpl.java
@@ -381,7 +381,7 @@ public class LiKafkaFederatedProducerImpl<K, V> implements LiKafkaProducer<K, V>
 
     _latchForTest.countDown();
 
-    LOG.info("Successfully restarted LiKafkaProducers in clusterGroup {} with new configs (diff) {}", _clusterGroup, newConfigs);
+    LOG.info("Successfully updated LiKafkaProducers configs in clusterGroup {} with new configs (diff) {}", _clusterGroup, newConfigs);
   }
 
   // For testing only, wait for reload config command to finish since it's being executed by a different thread

--- a/li-apache-kafka-clients/src/test/java/com/linkedin/kafka/clients/consumer/LiKafkaFederatedConsumerImplTest.java
+++ b/li-apache-kafka-clients/src/test/java/com/linkedin/kafka/clients/consumer/LiKafkaFederatedConsumerImplTest.java
@@ -9,6 +9,7 @@ import com.linkedin.kafka.clients.common.ClusterGroupDescriptor;
 import com.linkedin.kafka.clients.metadataservice.MetadataServiceClient;
 import com.linkedin.kafka.clients.metadataservice.MetadataServiceClientException;
 
+import com.linkedin.mario.common.websockets.MsgType;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -161,6 +162,64 @@ public class LiKafkaFederatedConsumerImplTest {
     _federatedConsumer.close();
     assertTrue("Consumer for cluster 1 should have been closed", consumer1.closed());
     assertTrue("Consumer for cluster 2 should have been closed", consumer2.closed());
+  }
+
+  @Test
+  public void testConsumerReloadConfigCommand() throws MetadataServiceClientException, InterruptedException {
+    // Set expectations so that topics 1 and 3 are hosted in cluster 1 and topic 2 in cluster 2.
+    Collection<TopicPartition> expectedTopicPartitions = Arrays.asList(TOPIC_PARTITION1, TOPIC_PARTITION2,
+        TOPIC_PARTITION3);
+    Map<TopicPartition, ClusterDescriptor> topicPartitionsToClusterMapToReturn =
+        new HashMap<TopicPartition, ClusterDescriptor>() {{
+          put(TOPIC_PARTITION1, CLUSTER1);
+          put(TOPIC_PARTITION2, CLUSTER2);
+          put(TOPIC_PARTITION3, CLUSTER1);
+        }};
+    when(_mdsClient.getClustersForTopicPartitions(eq(expectedTopicPartitions), eq(CLUSTER_GROUP), anyInt()))
+        .thenReturn(topicPartitionsToClusterMapToReturn);
+
+    // Assign topic partitions from all three topics
+    _federatedConsumer.assign(Arrays.asList(TOPIC_PARTITION1, TOPIC_PARTITION2, TOPIC_PARTITION3));
+
+    // Verify consumers for both clusters have been created.
+    MockConsumer consumer1 = ((MockLiKafkaConsumer) _federatedConsumer.getPerClusterConsumer(CLUSTER1)).getDelegate();
+    MockConsumer consumer2 = ((MockLiKafkaConsumer) _federatedConsumer.getPerClusterConsumer(CLUSTER2)).getDelegate();
+    assertNotNull("Consumer for cluster 1 should have been created", consumer1);
+    assertNotNull("Consumer for cluster 2 should have been created", consumer2);
+
+    // send reload config command
+    Map<String, String> newConfigs = new HashMap<>();
+    newConfigs.put("K1", "V1");
+    newConfigs.put("K2", "V2");
+    UUID commandId = UUID.randomUUID();
+
+    _federatedConsumer.reloadConfig(newConfigs, commandId);
+
+    // wait for reload config to finish
+    _federatedConsumer.waitForReloadConfigFinish();
+
+    // verify corresponding marioClient method is only called once
+    verify(_mdsClient, times(1)).reportCommandExecutionComplete(eq(commandId), any(), eq(MsgType.RELOAD_CONFIG_RESPONSE));
+    verify(_mdsClient, times(1)).reRegisterFederatedClient(any());
+
+    // Verify per-cluster consumers have been cleared after reload config command
+    assertNull("Consumer for cluster 1 should have been cleared",
+        _federatedConsumer.getPerClusterConsumer(CLUSTER1));
+    assertNull("Consumer for cluster 2 should have been cleared",
+        _federatedConsumer.getPerClusterConsumer(CLUSTER2));
+
+    // assing partitions again in order to create per-cluster consumers
+    _federatedConsumer.assign(Arrays.asList(TOPIC_PARTITION1, TOPIC_PARTITION2, TOPIC_PARTITION3));
+
+    // Verify consumers for both clusters have been created.
+    MockConsumer newConsumer1 = ((MockLiKafkaConsumer) _federatedConsumer.getPerClusterConsumer(CLUSTER1)).getDelegate();
+    MockConsumer newConsumer2 = ((MockLiKafkaConsumer) _federatedConsumer.getPerClusterConsumer(CLUSTER2)).getDelegate();
+    assertNotNull("Consumer for cluster 1 should have been created", newConsumer1);
+    assertNotNull("Consumer for cluster 2 should have been created", newConsumer2);
+
+    // verify after reload config, the common consumer configs contains the new configs from config reload command
+    assertTrue(_federatedConsumer.getCommonConsumerConfigs().originals().containsKey("K1"));
+    assertTrue(_federatedConsumer.getCommonConsumerConfigs().originals().containsKey("K2"));
   }
 
   private boolean isError(Future<?> future) {

--- a/li-apache-kafka-clients/src/test/java/com/linkedin/kafka/clients/consumer/LiKafkaFederatedConsumerImplTest.java
+++ b/li-apache-kafka-clients/src/test/java/com/linkedin/kafka/clients/consumer/LiKafkaFederatedConsumerImplTest.java
@@ -220,6 +220,10 @@ public class LiKafkaFederatedConsumerImplTest {
     // verify after reload config, the common consumer configs contains the new configs from config reload command
     assertTrue(_federatedConsumer.getCommonConsumerConfigs().originals().containsKey("K1"));
     assertTrue(_federatedConsumer.getCommonConsumerConfigs().originals().containsKey("K2"));
+
+    // Verify per-cluster consumers are not in closed state.
+    assertFalse("Consumer for cluster 1 should have not been closed", newConsumer1.closed());
+    assertFalse("Consumer for cluster 2 should have not been closed", newConsumer2.closed());
   }
 
   private boolean isError(Future<?> future) {

--- a/li-apache-kafka-clients/src/test/java/com/linkedin/kafka/clients/producer/LiKafkaFederatedProducerImplTest.java
+++ b/li-apache-kafka-clients/src/test/java/com/linkedin/kafka/clients/producer/LiKafkaFederatedProducerImplTest.java
@@ -142,7 +142,7 @@ public class LiKafkaFederatedProducerImplTest {
   }
 
   @Test
-  public void testReloadConfigCommand() throws MetadataServiceClientException {
+  public void testReloadConfigCommand() throws MetadataServiceClientException, InterruptedException {
     // Set expectations so that topics 1 and 3 are hosted in cluster 1 and topic 2 in cluster 2.
     when(_mdsClient.getClusterForTopic(eq(TOPIC1), eq(CLUSTER_GROUP), anyInt())).thenReturn(CLUSTER1);
     when(_mdsClient.getClusterForTopic(eq(TOPIC2), eq(CLUSTER_GROUP), anyInt())).thenReturn(CLUSTER2);
@@ -171,6 +171,9 @@ public class LiKafkaFederatedProducerImplTest {
     UUID commandId = UUID.randomUUID();
 
     _federatedProducer.reloadConfig(newConfigs, commandId);
+
+    // wait for reload config finish
+    _federatedProducer.waitForReloadConfigFinish();
 
     // verify corresponding marioClient method is only called once
     verify(_mdsClient, times(1)).reportCommandExecutionComplete(eq(commandId), any(), eq(MsgType.RELOAD_CONFIG_RESPONSE));


### PR DESCRIPTION
Add federated consumer config reload support, basically same flow as federated producer, i.e. upon receiving the reload config command, spin another thread, close the consumer, then apply the new configs. Assumption here is that all other consuming methods will be creating per-cluster consumers, so we don't re-create per-cluster consumers during reload config.