### PR TITLE
recreate producers and consumers during config reload command

### DIFF
--- a/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/consumer/LiKafkaFederatedConsumerImpl.java
+++ b/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/consumer/LiKafkaFederatedConsumerImpl.java
@@ -214,8 +214,7 @@ public class LiKafkaFederatedConsumerImpl<K, V> implements LiKafkaConsumer<K, V>
     throw new UnsupportedOperationException("Not implemented yet");
   }
 
-  @Override
-  synchronized public void assign(Collection<TopicPartition> partitions) {
+  private Map<ClusterDescriptor, Set<TopicPartition>> getPerClusterTopicPartitionSet(Collection<TopicPartition> partitions) {
     ensureOpen();
     if (partitions == null) {
       throw new IllegalArgumentException("Topic partition collection to assign to cannot be null");
@@ -225,7 +224,7 @@ public class LiKafkaFederatedConsumerImpl<K, V> implements LiKafkaConsumer<K, V>
     // behavior.
     if (partitions.isEmpty()) {
       unsubscribe();
-      return;
+      return null;
     }
 
     Map<TopicPartition, ClusterDescriptor> topicPartitionToClusterMap;
@@ -251,6 +250,18 @@ public class LiKafkaFederatedConsumerImpl<K, V> implements LiKafkaConsumer<K, V>
 
     if (!nonexistentTopicPartitions.isEmpty()) {
       throw new IllegalStateException("Cannot assign nonexistent partitions: " + nonexistentTopicPartitions);
+    }
+
+    return clusterToTopicPartitionsMap;
+  }
+
+  @Override
+  synchronized public void assign(Collection<TopicPartition> partitions) {
+    Map<ClusterDescriptor, Set<TopicPartition>> clusterToTopicPartitionsMap = getPerClusterTopicPartitionSet(partitions);
+
+    if (clusterToTopicPartitionsMap == null || clusterToTopicPartitionsMap.isEmpty()) {
+      LOG.debug("per-cluster topic partition set is empty, nothing to assign");
+      return;
     }
 
     // This assignment should replace the previous assignment. Since max.poll.records should be reset for consumers
@@ -618,6 +629,8 @@ public class LiKafkaFederatedConsumerImpl<K, V> implements LiKafkaConsumer<K, V>
     // let mario decide what to do next (re-send the configs etc).
     ensureOpen();
 
+    Set<TopicPartition> curPartitions = assignment();
+
     closeNoLock(RELOAD_CONFIG_EXECUTION_TIME_OUT.toMillis(), TimeUnit.MILLISECONDS);
 
     // save the original configs in case re-create consumers with new configs failed, we need to re-create
@@ -662,6 +675,14 @@ public class LiKafkaFederatedConsumerImpl<K, V> implements LiKafkaConsumer<K, V>
     }
 
     _closed = false;
+
+    // keep previous partition assignment after config reload
+    Map<ClusterDescriptor, Set<TopicPartition>> perClusterTopicPartitionSet = getPerClusterTopicPartitionSet(curPartitions);
+
+    for (Map.Entry<ClusterDescriptor, Set<TopicPartition>> entry : perClusterTopicPartitionSet.entrySet()) {
+      getOrCreatePerClusterConsumer(entry.getKey()).assign(entry.getValue());
+    }
+
 
     // Convert the updated configs from Map<String, Object> to Map<String, String> and send the new config to mario server
     // report reload config execution complete to mario server

--- a/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/consumer/LiKafkaFederatedConsumerImpl.java
+++ b/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/consumer/LiKafkaFederatedConsumerImpl.java
@@ -677,6 +677,7 @@ public class LiKafkaFederatedConsumerImpl<K, V> implements LiKafkaConsumer<K, V>
     _closed = false;
 
     // keep previous partition assignment after config reload
+    // TODO: after subscribe() is supported, we need to also keep the original subscription
     Map<ClusterDescriptor, Set<TopicPartition>> perClusterTopicPartitionSet = getPerClusterTopicPartitionSet(curPartitions);
 
     for (Map.Entry<ClusterDescriptor, Set<TopicPartition>> entry : perClusterTopicPartitionSet.entrySet()) {

--- a/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/producer/LiKafkaFederatedProducerImpl.java
+++ b/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/producer/LiKafkaFederatedProducerImpl.java
@@ -339,7 +339,7 @@ public class LiKafkaFederatedProducerImpl<K, V> implements LiKafkaProducer<K, V>
     // since this method is invoked by marioClient, it should be non-blocking, so we create another thread doing above
     LOG.info("Starting reloadConfig for LiKafkaProducers in clusterGroup {} with new configs {}", _clusterGroup, newConfigs);
     Thread t = new Thread(() -> {
-        flushAndCloseExistingProducers(newConfigs, commandId);
+        recreateProducers(newConfigs, commandId);
     });
     t.setDaemon(true);
     t.setName("LiKafkaProducer-reloadConfig-" + _clusterGroup.getName());
@@ -353,11 +353,17 @@ public class LiKafkaFederatedProducerImpl<K, V> implements LiKafkaProducer<K, V>
   }
 
   // Do synchronization on the method that will be flushing and closing the producers since it will be handled by a different thread
-  synchronized void flushAndCloseExistingProducers(Map<String, String> newConfigs, UUID commandId) {
+  synchronized void recreateProducers(Map<String, String> newConfigs, UUID commandId) {
     ensureOpen();
 
     flushNoLock(RELOAD_CONFIG_EXECUTION_TIME_OUT.toMillis(), TimeUnit.MILLISECONDS);
     closeNoLock(RELOAD_CONFIG_EXECUTION_TIME_OUT.toMillis(), TimeUnit.MILLISECONDS);
+
+    _closed = false;
+
+    // save the original configs in case re-create producers with new configs failed, we need to re-create
+    // with the original configs
+    Map<String, Object> originalConfig = _commonProducerConfigs.originals();
 
     // update existing configs with newConfigs
     // originals() would return a copy of the internal producer configs, put in new configs and update existing configs
@@ -365,16 +371,47 @@ public class LiKafkaFederatedProducerImpl<K, V> implements LiKafkaProducer<K, V>
     configMap.putAll(newConfigs);
     _commonProducerConfigs = new LiKafkaProducerConfig(configMap);
 
-    // reset the state of _producers and _closed so that subsequent send will try to instantiate the producers with new configs
-    _producers.clear();
-    _closed = false;
+    // re-create per-cluster producers with new set of configs
+    // if any error occurs, recreate all per-cluster producers with previous last-known-good configs and
+    // TODO : send an error back to Mario
+    // _producers should be filled when reload config happens
+    Map<ClusterDescriptor, LiKafkaProducer<K, V>> newProducers = new ConcurrentHashMap<>();
+    boolean recreateSucceeded = false;
+
+    try {
+      for (Map.Entry<ClusterDescriptor, LiKafkaProducer<K, V>> entry : _producers.entrySet()) {
+        getOrCreatePerClusterProducer(entry.getKey(), newProducers);
+      }
+
+      recreateSucceeded = true;
+    } catch (Exception e) {
+      LOG.error("Failed to recreate per-cluster producers with new configs, exception ", e);
+    }
+
+    if (recreateSucceeded) {
+      // replace _producers with newly created producers
+      _producers.clear();
+      _producers = newProducers;
+    } else {
+      // recreate failed, restore to previous configured producers
+      newProducers.clear();
+      _commonProducerConfigs = new LiKafkaProducerConfig(originalConfig);
+
+      for (Map.Entry<ClusterDescriptor, LiKafkaProducer<K, V>> entry : _producers.entrySet()) {
+        getOrCreatePerClusterProducer(entry.getKey(), newProducers);
+      }
+
+      _producers = newProducers;
+    }
 
     // Convert the updated configs from Map<String, Object> to Map<String, String> and send the new config to mario server
     // report reload config execution complete to mario server
     Map<String, String> convertedConfig = new HashMap<>();
-    for (Map.Entry<String, Object> entry : configMap.entrySet()) {
+    for (Map.Entry<String, Object> entry : _commonProducerConfigs.originals().entrySet()) {
       convertedConfig.put(entry.getKey(), String.valueOf(entry.getValue()));
     }
+    // TODO: add a flag in RELOAD_CONFIG_RESPONSE message to indicate result of config reload
+    // TODO: add a flag in RELOAD_CONFIG_RESPONSE message to indicate result of config reload
     _mdsClient.reportCommandExecutionComplete(commandId, convertedConfig, MsgType.RELOAD_CONFIG_RESPONSE);
 
     // re-register federated client with updated configs
@@ -382,7 +419,7 @@ public class LiKafkaFederatedProducerImpl<K, V> implements LiKafkaProducer<K, V>
 
     _numConfigReloads++;
 
-    LOG.info("Successfully updated LiKafkaProducers configs in clusterGroup {} with new configs (diff) {}", _clusterGroup, newConfigs);
+    LOG.info("Successfully recreated LiKafkaProducers in clusterGroup {} with new configs (diff) {}", _clusterGroup, newConfigs);
   }
 
   // For testing only, wait for reload config command to finish since it's being executed by a different thread
@@ -415,18 +452,18 @@ public class LiKafkaFederatedProducerImpl<K, V> implements LiKafkaProducer<K, V>
     if (cluster == null) {
       throw new IllegalStateException("Topic " + topic + " not found in the metadata service");
     }
-    return getOrCreatePerClusterProducer(cluster);
+    return getOrCreatePerClusterProducer(cluster, _producers);
   }
 
-  private LiKafkaProducer<K, V> getOrCreatePerClusterProducer(ClusterDescriptor cluster) {
+  private LiKafkaProducer<K, V> getOrCreatePerClusterProducer(ClusterDescriptor cluster, Map<ClusterDescriptor, LiKafkaProducer<K, V>> producers) {
     if (cluster == null) {
       throw new IllegalArgumentException("Cluster cannot be null");
     }
 
     ensureOpen();
 
-    if (_producers.containsKey(cluster)) {
-      return _producers.get(cluster);
+    if (producers.containsKey(cluster)) {
+      return producers.get(cluster);
     }
 
     // Create per-cluster producer config
@@ -436,7 +473,7 @@ public class LiKafkaFederatedProducerImpl<K, V> implements LiKafkaProducer<K, V>
 
     _producerBuilder.setProducerConfig(configMap);
     LiKafkaProducer<K, V> newProducer = _producerBuilder.build();
-    _producers.put(cluster, newProducer);
+    producers.put(cluster, newProducer);
     return newProducer;
   }
 

--- a/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/producer/LiKafkaFederatedProducerImpl.java
+++ b/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/producer/LiKafkaFederatedProducerImpl.java
@@ -408,7 +408,6 @@ public class LiKafkaFederatedProducerImpl<K, V> implements LiKafkaProducer<K, V>
       convertedConfig.put(entry.getKey(), String.valueOf(entry.getValue()));
     }
     // TODO: add a flag in RELOAD_CONFIG_RESPONSE message to indicate result of config reload
-    // TODO: add a flag in RELOAD_CONFIG_RESPONSE message to indicate result of config reload
     _mdsClient.reportCommandExecutionComplete(commandId, convertedConfig, MsgType.RELOAD_CONFIG_RESPONSE);
 
     // re-register federated client with updated configs

--- a/li-apache-kafka-clients/src/test/java/com/linkedin/kafka/clients/consumer/LiKafkaFederatedConsumerImplTest.java
+++ b/li-apache-kafka-clients/src/test/java/com/linkedin/kafka/clients/consumer/LiKafkaFederatedConsumerImplTest.java
@@ -202,15 +202,6 @@ public class LiKafkaFederatedConsumerImplTest {
     verify(_mdsClient, times(1)).reportCommandExecutionComplete(eq(commandId), any(), eq(MsgType.RELOAD_CONFIG_RESPONSE));
     verify(_mdsClient, times(1)).reRegisterFederatedClient(any());
 
-    // Verify per-cluster consumers have been cleared after reload config command
-    assertNull("Consumer for cluster 1 should have been cleared",
-        _federatedConsumer.getPerClusterConsumer(CLUSTER1));
-    assertNull("Consumer for cluster 2 should have been cleared",
-        _federatedConsumer.getPerClusterConsumer(CLUSTER2));
-
-    // assing partitions again in order to create per-cluster consumers
-    _federatedConsumer.assign(Arrays.asList(TOPIC_PARTITION1, TOPIC_PARTITION2, TOPIC_PARTITION3));
-
     // Verify consumers for both clusters have been created.
     MockConsumer newConsumer1 = ((MockLiKafkaConsumer) _federatedConsumer.getPerClusterConsumer(CLUSTER1)).getDelegate();
     MockConsumer newConsumer2 = ((MockLiKafkaConsumer) _federatedConsumer.getPerClusterConsumer(CLUSTER2)).getDelegate();

--- a/li-apache-kafka-clients/src/test/java/com/linkedin/kafka/clients/consumer/LiKafkaFederatedConsumerImplTest.java
+++ b/li-apache-kafka-clients/src/test/java/com/linkedin/kafka/clients/consumer/LiKafkaFederatedConsumerImplTest.java
@@ -16,6 +16,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.Future;
 
@@ -175,11 +176,13 @@ public class LiKafkaFederatedConsumerImplTest {
           put(TOPIC_PARTITION2, CLUSTER2);
           put(TOPIC_PARTITION3, CLUSTER1);
         }};
-    when(_mdsClient.getClustersForTopicPartitions(eq(expectedTopicPartitions), eq(CLUSTER_GROUP), anyInt()))
+    when(_mdsClient.getClustersForTopicPartitions(anyCollection(), eq(CLUSTER_GROUP), anyInt()))
         .thenReturn(topicPartitionsToClusterMapToReturn);
 
     // Assign topic partitions from all three topics
     _federatedConsumer.assign(Arrays.asList(TOPIC_PARTITION1, TOPIC_PARTITION2, TOPIC_PARTITION3));
+
+    Set<TopicPartition> curAssignment = _federatedConsumer.assignment();
 
     // Verify consumers for both clusters have been created.
     MockConsumer consumer1 = ((MockLiKafkaConsumer) _federatedConsumer.getPerClusterConsumer(CLUSTER1)).getDelegate();
@@ -215,6 +218,9 @@ public class LiKafkaFederatedConsumerImplTest {
     // Verify per-cluster consumers are not in closed state.
     assertFalse("Consumer for cluster 1 should have not been closed", newConsumer1.closed());
     assertFalse("Consumer for cluster 2 should have not been closed", newConsumer2.closed());
+
+    // Verify the topic partition assignment remains the same after reload config
+    assertEquals(_federatedConsumer.assignment(), curAssignment);
   }
 
   private boolean isError(Future<?> future) {

--- a/li-apache-kafka-clients/src/test/java/com/linkedin/kafka/clients/producer/LiKafkaFederatedProducerImplTest.java
+++ b/li-apache-kafka-clients/src/test/java/com/linkedin/kafka/clients/producer/LiKafkaFederatedProducerImplTest.java
@@ -179,10 +179,10 @@ public class LiKafkaFederatedProducerImplTest {
     verify(_mdsClient, times(1)).reportCommandExecutionComplete(eq(commandId), any(), eq(MsgType.RELOAD_CONFIG_RESPONSE));
     verify(_mdsClient, times(1)).reRegisterFederatedClient(any());
 
-    // verify per-cluster producers have been cleared after reloadConfig
-    assertNull("Producer for cluster 1 should have been cleared",
+    // verify per-cluster producers have been recreated after reloadConfig
+    assertNotNull("Producer for cluster 1 should have been cleared",
         _federatedProducer.getPerClusterProducer(CLUSTER1));
-    assertNull("Producer for cluster 2 should have been cleared",
+    assertNotNull("Producer for cluster 2 should have been cleared",
         _federatedProducer.getPerClusterProducer(CLUSTER2));
 
     // verify after reload config, the common producer configs contains the new configs from config reload command


### PR DESCRIPTION
Re-create producers and consumers as part of config reload command instead of lazy construction to avoid delay of errors and user impact.