### PR TITLE
Make KafkaConsumer poll(long) and poll(Duration) API visible to LiKaf…

### DIFF
--- a/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/consumer/LiKafkaConsumerImpl.java
+++ b/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/consumer/LiKafkaConsumerImpl.java
@@ -286,6 +286,7 @@ public class LiKafkaConsumerImpl<K, V> implements LiKafkaConsumer<K, V> {
   }
 
   @Override
+  @Deprecated
   public ConsumerRecords<K, V> poll(long timeout) {
     return poll(timeout, false);
   }

--- a/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/consumer/LiKafkaConsumerImpl.java
+++ b/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/consumer/LiKafkaConsumerImpl.java
@@ -285,6 +285,14 @@ public class LiKafkaConsumerImpl<K, V> implements LiKafkaConsumer<K, V> {
     return processedRecords;
   }
 
+  /**
+   * We still need this API for at least one specific case in Kafka-Rest. poll((long) 0) is used by Kafka-Rest's background threads
+   * to do rebalance. We cannot use poll(Duration 0) because poll(Duration) includes metadata update time in the Duration,
+   * so we end up exiting too soon to finish rebalance. poll((long) 0) on the other hand will wait for as long as it takes
+   * to rebalance, which is the desired behavior.
+   * @param timeout timeout in milliseconds for poll. Excludes metadata update time
+   * @return {@link ConsumerRecords}
+   */
   @Override
   @Deprecated
   public ConsumerRecords<K, V> poll(long timeout) {


### PR DESCRIPTION
Currently `poll(long)` and `poll(Duration)` in `LiKafkaConsumerImpl` both call `KafkaConsumer.poll(Duration)`. We need to expose both of `KafkaConsumer`'s `poll()` in `LiKafkaConsumerImpl` so that `kafka-rest` can leverage them.