### PR TITLE
Add support for config push at boot up time

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ project.ext {
     }
   }
   kafkaVersion = "2.0.1"
-  marioVersion = "0.0.7"
+  marioVersion = "0.0.8"
 }
 
 subprojects {

--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ project.ext {
     }
   }
   kafkaVersion = "2.0.1"
-  marioVersion = "0.0.6"
+  marioVersion = "0.0.7"
 }
 
 subprojects {

--- a/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/consumer/LiKafkaFederatedConsumerImpl.java
+++ b/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/consumer/LiKafkaFederatedConsumerImpl.java
@@ -367,7 +367,7 @@ public class LiKafkaFederatedConsumerImpl<K, V> implements LiKafkaConsumer<K, V>
 
     for (Map.Entry<ClusterDescriptor, Set<String>> entry : topicsByCluster.entrySet()) {
       ClusterDescriptor cluster = entry.getKey();
-      LiKafkaConsumer<K, V> consumer = getOrCreatePerClusterConsumer(cluster);
+      LiKafkaConsumer<K, V> consumer = createPerClusterConsumer(cluster);
       // TODO: create a wrapper callback that supports federation
       consumer.subscribe(entry.getValue(), callback);
       _consumers.add(new ClusterConsumerPair<K, V>(cluster, consumer));
@@ -417,7 +417,7 @@ public class LiKafkaFederatedConsumerImpl<K, V> implements LiKafkaConsumer<K, V>
     _nextClusterIndexToPoll = 0;
 
     for (Map.Entry<ClusterDescriptor, Set<TopicPartition>> entry : partitionsByCluster.entrySet()) {
-      LiKafkaConsumer<K, V> consumer = getOrCreatePerClusterConsumer(entry.getKey());
+      LiKafkaConsumer<K, V> consumer = createPerClusterConsumer(entry.getKey());
       consumer.assign(entry.getValue());
       _consumers.add(new ClusterConsumerPair<K, V>(entry.getKey(), consumer));
     }

--- a/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/metadataservice/MetadataServiceClient.java
+++ b/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/metadataservice/MetadataServiceClient.java
@@ -29,7 +29,7 @@ public interface MetadataServiceClient extends Configurable, AutoCloseable {
    * @param configs         Client configs
    * @param timeoutMs       Timeout in milliseconds
    */
-  boolean registerFederatedClient(LiKafkaFederatedClient federatedClient, ClusterGroupDescriptor clusterGroup,
+  void registerFederatedClient(LiKafkaFederatedClient federatedClient, ClusterGroupDescriptor clusterGroup,
       Map<String, ?> configs, int timeoutMs);
 
   /**

--- a/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/metadataservice/MetadataServiceClient.java
+++ b/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/metadataservice/MetadataServiceClient.java
@@ -10,7 +10,7 @@ import com.linkedin.kafka.clients.common.LiKafkaFederatedClient;
 import com.linkedin.kafka.clients.common.PartitionLookupResult;
 import com.linkedin.kafka.clients.common.TopicLookupResult;
 
-import com.linkedin.mario.common.websockets.MsgType;
+import com.linkedin.mario.common.websockets.MessageType;
 import java.util.Map;
 import java.util.Set;
 
@@ -29,7 +29,7 @@ public interface MetadataServiceClient extends Configurable, AutoCloseable {
    * @param configs         Client configs
    * @param timeoutMs       Timeout in milliseconds
    */
-  void registerFederatedClient(LiKafkaFederatedClient federatedClient, ClusterGroupDescriptor clusterGroup,
+  boolean registerFederatedClient(LiKafkaFederatedClient federatedClient, ClusterGroupDescriptor clusterGroup,
       Map<String, ?> configs, int timeoutMs);
 
   /**
@@ -67,11 +67,12 @@ public interface MetadataServiceClient extends Configurable, AutoCloseable {
 
   /**
    * Report to mario server that command execution for commandId is completed
-   * @param commandId    UUID identifying the completed command
-   * @param configs      config diff before and after the command
-   * @param messageType  response message type to mario server
+   * @param commandId                UUID identifying the completed command
+   * @param configs                  config diff before and after the command
+   * @param messageType              response message type to mario server
+   * @param commandExecutionResult   execution result of the given command
    */
-  void reportCommandExecutionComplete(UUID commandId, Map<String, String> configs, MsgType messageType);
+  void reportCommandExecutionComplete(UUID commandId, Map<String, String> configs, MessageType messageType, boolean commandExecutionResult);
 
   /**
    * Re-register federated client with new set of configs

--- a/li-apache-kafka-clients/src/test/java/com/linkedin/kafka/clients/metadataservice/MarioMetadataServiceClientTest.java
+++ b/li-apache-kafka-clients/src/test/java/com/linkedin/kafka/clients/metadataservice/MarioMetadataServiceClientTest.java
@@ -76,7 +76,7 @@ public class MarioMetadataServiceClientTest {
   }
 
   @Test
-  public void testRegisterFederatedClient() throws MetadataServiceClientException {
+  public void testRegisterFederatedClient() throws MetadataServiceClientException, Exception {
     Map<String, String> configs = new HashMap<>();
     configs.put("K1", "V1");
     configs.put("K2", "V2");

--- a/li-apache-kafka-clients/src/test/java/com/linkedin/kafka/clients/metadataservice/MarioMetadataServiceClientTest.java
+++ b/li-apache-kafka-clients/src/test/java/com/linkedin/kafka/clients/metadataservice/MarioMetadataServiceClientTest.java
@@ -87,7 +87,7 @@ public class MarioMetadataServiceClientTest {
     // For now, simply verify the corresponding MarioClient method is called once with expected arguments.
     MarioClusterGroupDescriptor expectedMarioClusterGroup = new MarioClusterGroupDescriptor(CLUSTER_GROUP.getName(),
         CLUSTER_GROUP.getEnvironment());
-    verify(_marioClient, times(1)).registerFederatedClient(eq(expectedMarioClusterGroup), eq(configs), eq(100),
+    verify(_marioClient, times(1)).registerFederatedClient(eq(expectedMarioClusterGroup), eq(configs), eq(100L),
         any(MarioCommandCallback.class));
   }
 


### PR DESCRIPTION
Adds support for config push at boot up time. When federated client registers itself to Mario, Mario will return a set of configs it wants federated client to apply at boot up time. This set of configs is saved first then applied when actually creating per-cluster clients.