### PR TITLE
Bump up mario version to 0.0.9

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ project.ext {
     }
   }
   kafkaVersion = "2.0.1"
-  marioVersion = "0.0.8"
+  marioVersion = "0.0.9"
 }
 
 subprojects {


### PR DESCRIPTION
Bump up mario version to avoid leaking log4j2 bindings to downstream dependencies.