### PR TITLE
initial implementation of instrumented clients

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ project.ext {
     }
   }
   kafkaVersion = "2.0.1"
-  marioVersion = "0.0.9"
+  marioVersion = "0.0.12"
 }
 
 subprojects {

--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -10,4 +10,7 @@ plugins {
 
 dependencies {
   testCompile project(':kafka-test-harness')
+  testCompile ("com.linkedin.mario:mario-integration-tests:${rootProject.ext.marioVersion}") {
+    exclude group: 'org.apache.kafka'
+  }
 }

--- a/integration-tests/src/test/java/com/linkedin/kafka/clients/consumer/LiKafkaConsumerIntegrationTest.java
+++ b/integration-tests/src/test/java/com/linkedin/kafka/clients/consumer/LiKafkaConsumerIntegrationTest.java
@@ -50,7 +50,6 @@ import org.apache.kafka.clients.consumer.OffsetAndTimestamp;
 import org.apache.kafka.clients.consumer.OffsetCommitCallback;
 import org.apache.kafka.clients.consumer.OffsetOutOfRangeException;
 import org.apache.kafka.clients.producer.Callback;
-import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
@@ -60,7 +59,6 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.SerializationException;
 import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
-import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
@@ -126,7 +124,7 @@ public class LiKafkaConsumerIntegrationTest extends AbstractKafkaClientsIntegrat
     int buriedMessageCount = 1_000;
     int syntheticMessageCount = 10;
     int totalMessageCount = buriedMessageCount + syntheticMessageCount;
-    Producer<byte[], byte[]> extraMessagesProducer = createKafkaProducer();
+    Producer<byte[], byte[]> extraMessagesProducer = createRawProducer();
     for (int i = 0; i < buriedMessageCount; i++) {
       UUID messageId = LiKafkaClientsUtils.randomUUID();
       String message = LiKafkaClientsTestUtils.getRandomString(MAX_SEGMENT_SIZE / 2);
@@ -1190,7 +1188,7 @@ public class LiKafkaConsumerIntegrationTest extends AbstractKafkaClientsIntegrat
 
     //send 2 interleaved gigantic msgs
 
-    Producer<byte[], byte[]> producer = createKafkaProducer();
+    Producer<byte[], byte[]> producer = createRawProducer();
     // M0, 20 segments
     UUID messageId0 = LiKafkaClientsUtils.randomUUID();
     String message0 = KafkaTestUtils.getRandomString(20 * MAX_SEGMENT_SIZE);
@@ -1268,7 +1266,7 @@ public class LiKafkaConsumerIntegrationTest extends AbstractKafkaClientsIntegrat
 
     //send a gigantic msg
 
-    Producer<byte[], byte[]> producer = createKafkaProducer();
+    Producer<byte[], byte[]> producer = createRawProducer();
     // M0, 20 segments
     UUID messageId0 = LiKafkaClientsUtils.randomUUID();
     String message0 = KafkaTestUtils.getRandomString(20 * MAX_SEGMENT_SIZE);
@@ -1639,7 +1637,7 @@ public class LiKafkaConsumerIntegrationTest extends AbstractKafkaClientsIntegrat
         new DefaultSegmentSerializer(),
         new UUIDFactory.DefaultUUIDFactory<>());
 
-    Producer<byte[], byte[]> producer = createKafkaProducer();
+    Producer<byte[], byte[]> producer = createRawProducer();
     // Prepare messages.
     int messageSize = MAX_SEGMENT_SIZE + MAX_SEGMENT_SIZE / 2;
     // M0, 2 segments
@@ -1691,15 +1689,6 @@ public class LiKafkaConsumerIntegrationTest extends AbstractKafkaClientsIntegrat
       fail("Produce synthetic data failed.", e);
     }
     producer.close();
-  }
-
-  //TODO - remove / refactor
-  private Producer<byte[], byte[]> createKafkaProducer() {
-    Properties props = new Properties();
-    props.setProperty(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class.getCanonicalName());
-    props.setProperty(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class.getCanonicalName());
-    Properties finalProducerProps = getProducerProperties(props);
-    return new KafkaProducer(finalProducerProps);
   }
 
   private class RebalanceTestConsumerThread extends Thread {

--- a/integration-tests/src/test/java/com/linkedin/kafka/clients/consumer/LiKafkaInstrumentedConsumerIntegrationTest.java
+++ b/integration-tests/src/test/java/com/linkedin/kafka/clients/consumer/LiKafkaInstrumentedConsumerIntegrationTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2017 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License").  See License in the project root for license information.
+ */
+
+package com.linkedin.kafka.clients.consumer;
+
+import com.google.common.collect.ImmutableMap;
+import com.linkedin.kafka.clients.utils.tests.AbstractKafkaClientsIntegrationTestHarness;
+import com.linkedin.mario.common.models.v1.ClientConfigRule;
+import com.linkedin.mario.common.models.v1.ClientConfigRules;
+import com.linkedin.mario.common.models.v1.ClientPredicates;
+import com.linkedin.mario.server.MarioApplication;
+import com.linkedin.mario.test.TestUtils;
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
+import java.util.Random;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.TopicPartition;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+
+public class LiKafkaInstrumentedConsumerIntegrationTest extends AbstractKafkaClientsIntegrationTestHarness {
+
+  @BeforeMethod
+  @Override
+  public void setUp() {
+    super.setUp();
+  }
+
+  @AfterMethod
+  @Override
+  public void tearDown() {
+    super.tearDown();
+  }
+
+  @Test
+  public void testConsumerLiveConfigReload() throws Exception {
+    String topic = "testConsumerLiveConfigReload";
+
+    Producer<byte[], byte[]> producer = createRawProducer();
+    for (int i = 0; i < 1000; i++) {
+      byte[] key = new byte[1024];
+      byte[] value = new byte[1024];
+      Arrays.fill(key, (byte) i);
+      Arrays.fill(value, (byte) i);
+      ProducerRecord<byte[], byte[]> record = new ProducerRecord<>(topic, 0, key, value);
+      ByteArrayOutputStream bos = new ByteArrayOutputStream();
+      DataOutputStream dos = new DataOutputStream(bos);
+      dos.writeInt(i);
+      dos.close();
+      record.headers().add("recordNum", bos.toByteArray());
+      producer.send(record);
+    }
+    producer.flush();
+    producer.close(1, TimeUnit.MINUTES);
+
+    MarioApplication mario = new MarioApplication(null);
+    Random random = new Random();
+    int beforeBatchSize = 1 + random.nextInt(20); //[1, 20]
+
+    Properties extra = new Properties();
+    extra.setProperty(ConsumerConfig.GROUP_ID_CONFIG, UUID.randomUUID().toString());
+    extra.setProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+    extra.setProperty(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, "" + beforeBatchSize);
+    Properties baseConsumerConfig = getConsumerProperties(extra);
+    LiKafkaInstrumentedConsumerImpl<byte[], byte[]> consumer = new LiKafkaInstrumentedConsumerImpl<>(
+        baseConsumerConfig,
+        LiKafkaConsumerImpl::new,
+        mario.getUrl()
+    );
+
+    consumer.subscribe(Collections.singletonList(topic));
+    AtomicReference<ConsumerRecords<byte[], byte[]>> recordsRef = new AtomicReference<>(null);
+    AtomicReference<Consumer<byte[], byte[]>> delegateBeforeRef = new AtomicReference<>(null);
+    TestUtils.waitUntil("1st record batch", () -> {
+      ConsumerRecords<byte[], byte[]> recs = consumer.poll(Duration.ofSeconds(10));
+      if (recs.count() > 0) {
+        recordsRef.set(recs);
+        delegateBeforeRef.set(consumer.getDelegate());
+        return true;
+      }
+      return false;
+    }, 1, 2, TimeUnit.MINUTES, false);
+    ConsumerRecords<byte[], byte[]> firstBatch = recordsRef.get(); //guaranteed != null
+    Consumer<byte[], byte[]> delegate = delegateBeforeRef.get();
+
+    Assert.assertEquals(firstBatch.count(), beforeBatchSize);
+
+    TopicPartition p0 = new TopicPartition(topic, 0);
+    List<ConsumerRecord<byte[], byte[]>> records = firstBatch.records(p0);
+    ConsumerRecord<byte[], byte[]> lastRecordInFirstBatch = records.get(records.size() - 1);
+
+    int afterBatchSize = 31 + random.nextInt(20); //[31, 50]
+
+    //install a new config policy, wait for the push
+    mario.setConfigPolicy(new ClientConfigRules(Collections.singletonList(
+        new ClientConfigRule(ClientPredicates.ALL, ImmutableMap.of("max.poll.records", "" + afterBatchSize)))));
+
+    TestUtils.waitUntil("delegate recreated", () -> {
+      Consumer<byte[], byte[]> delegateNow = consumer.getDelegate();
+      return delegateNow != delegate;
+    }, 1, 2, TimeUnit.MINUTES, false);
+
+    TestUtils.waitUntil("1nd record batch", () -> {
+      ConsumerRecords<byte[], byte[]> recs = consumer.poll(Duration.ofSeconds(10));
+      if (recs.count() > 0) {
+        recordsRef.set(recs);
+        return true;
+      }
+      return false;
+    }, 1, 2, TimeUnit.MINUTES, false);
+
+    ConsumerRecords<byte[], byte[]> secondBatch = recordsRef.get(); //guaranteed != null
+    Assert.assertEquals(secondBatch.count(), afterBatchSize);
+
+    records = secondBatch.records(p0);
+    ConsumerRecord<byte[], byte[]> firstRecordInSecondBatch = records.get(0);
+
+    //make sure no skips
+    Assert.assertEquals(firstRecordInSecondBatch.offset(), lastRecordInFirstBatch.offset() + 1,
+        lastRecordInFirstBatch.offset() + " + 1 != " + firstRecordInSecondBatch.offset());
+
+    consumer.close(Duration.ofSeconds(30));
+    mario.close();
+  }
+}

--- a/integration-tests/src/test/java/com/linkedin/kafka/clients/producer/LiKafkaInstrumentedProducerIntegrationTest.java
+++ b/integration-tests/src/test/java/com/linkedin/kafka/clients/producer/LiKafkaInstrumentedProducerIntegrationTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2017 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License").  See License in the project root for license information.
+ */
+
+package com.linkedin.kafka.clients.producer;
+
+import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableMap;
+import com.linkedin.kafka.clients.utils.tests.AbstractKafkaClientsIntegrationTestHarness;
+import com.linkedin.mario.common.models.v1.ClientConfigRule;
+import com.linkedin.mario.common.models.v1.ClientConfigRules;
+import com.linkedin.mario.common.models.v1.ClientPredicates;
+import com.linkedin.mario.server.MarioApplication;
+import com.linkedin.mario.test.TestUtils;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Properties;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.common.errors.RecordTooLargeException;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+
+public class LiKafkaInstrumentedProducerIntegrationTest extends AbstractKafkaClientsIntegrationTestHarness {
+
+  @BeforeMethod
+  @Override
+  public void setUp() {
+    super.setUp();
+  }
+
+  @AfterMethod
+  @Override
+  public void tearDown() {
+    super.tearDown();
+  }
+
+  @Test
+  public void testProducerLiveConfigReload() throws Exception {
+    String topic = "testProducerLiveConfigReload";
+
+    MarioApplication mario = new MarioApplication(null);
+    Random random = new Random();
+
+    Properties extra = new Properties();
+    extra.setProperty(ProducerConfig.MAX_REQUEST_SIZE_CONFIG, "" + 1500);
+    extra.setProperty(ProducerConfig.ACKS_CONFIG, "1");
+    Properties baseProducerConfig = getConsumerProperties(extra);
+    LiKafkaInstrumentedProducerImpl<byte[], byte[]> producer = new LiKafkaInstrumentedProducerImpl<>(
+        baseProducerConfig,
+        LiKafkaProducerImpl::new,
+        mario.getUrl()
+    );
+
+    byte[] key = new byte[500];
+    byte[] value = new byte[500];
+    random.nextBytes(key);
+    random.nextBytes(value);
+    ProducerRecord<byte[], byte[]> record = new ProducerRecord<>(topic, 0, key, value);
+    RecordMetadata recordMetadata = producer.send(record).get();
+
+    Producer<byte[], byte[]> delegate = producer.getDelegate();
+
+    key = new byte[3000];
+    value = new byte[3000];
+    random.nextBytes(key);
+    random.nextBytes(value);
+    record = new ProducerRecord<>(topic, 0, key, value);
+    try {
+      producer.send(record).get();
+      Assert.fail("record expected to fail");
+    } catch (Exception e) {
+      Throwable root = Throwables.getRootCause(e);
+      Assert.assertTrue(root instanceof RecordTooLargeException, root.getClass() + " is not a RecordTooLargeException");
+    }
+
+    //install a new config policy, wait for the push
+    mario.setConfigPolicy(new ClientConfigRules(Collections.singletonList(
+        new ClientConfigRule(ClientPredicates.ALL, ImmutableMap.of("max.request.size", "" + 9000)))));
+
+    TestUtils.waitUntil("delegate recreated", () -> {
+      Producer<byte[], byte[]> delegateNow = producer.getDelegate();
+      return delegateNow != delegate;
+    }, 1, 2, TimeUnit.MINUTES, false);
+
+    producer.send(record).get(); //should succeed this time
+
+    producer.close(Duration.ofSeconds(30));
+    mario.close();
+  }
+}

--- a/kafka-test-harness/src/main/java/com/linkedin/kafka/clients/utils/tests/AbstractKafkaClientsIntegrationTestHarness.java
+++ b/kafka-test-harness/src/main/java/com/linkedin/kafka/clients/utils/tests/AbstractKafkaClientsIntegrationTestHarness.java
@@ -16,9 +16,12 @@ import java.io.File;
 import java.util.Properties;
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.network.Mode;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
+import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 
@@ -33,6 +36,14 @@ public abstract class AbstractKafkaClientsIntegrationTestHarness extends Abstrac
   protected LiKafkaProducer<String, String> createProducer(Properties overrides) {
     Properties props = getProducerProperties(overrides);
     return new LiKafkaProducerImpl<>(props);
+  }
+
+  protected Producer<byte[], byte[]> createRawProducer() {
+    Properties props = new Properties();
+    props.setProperty(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class.getCanonicalName());
+    props.setProperty(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class.getCanonicalName());
+    Properties finalProducerProps = getProducerProperties(props);
+    return new KafkaProducer<>(finalProducerProps);
   }
 
   protected Properties getProducerProperties(Properties overrides) {

--- a/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/common/MetricsProxy.java
+++ b/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/common/MetricsProxy.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2019 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License").  See License in the project root for license information.
+ */
+
+package com.linkedin.kafka.clients.common;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+import org.apache.kafka.common.Metric;
+import org.apache.kafka.common.MetricName;
+
+/**
+ * this class allows delegating kafka metrics to an underlying delegate
+ * kafka client, allowing the delegate to be replaced/recreated without
+ * "invalidating" metrics maps user code may hold on to.
+ */
+public abstract class MetricsProxy implements Map {
+
+  /**
+   * @return the metrics map for the current delegate client, or an empty map if none.
+   */
+  protected abstract Map<MetricName, ? extends Metric> getMetrics();
+
+  @Override
+  public int size() {
+    return getMetrics().size();
+  }
+
+  @Override
+  public boolean isEmpty() {
+    return getMetrics().isEmpty();
+  }
+
+  @Override
+  public boolean containsKey(Object key) {
+    return getMetrics().containsKey(key);
+  }
+
+  @Override
+  public boolean containsValue(Object value) {
+    return getMetrics().containsValue(value);
+  }
+
+  @Override
+  public Object get(Object key) {
+    return getMetrics().get(key);
+  }
+
+  @Override
+  public Metric put(Object key, Object value) {
+    throw new UnsupportedOperationException(); //this collection is immutable in vanilla kafka anyway
+  }
+
+  @Override
+  public Object remove(Object key) {
+    throw new UnsupportedOperationException(); //this collection is immutable in vanilla kafka anyway
+  }
+
+  @Override
+  public void putAll(Map m) {
+    throw new UnsupportedOperationException(); //this collection is immutable in vanilla kafka anyway
+  }
+
+  @Override
+  public void clear() {
+    throw new UnsupportedOperationException(); //this collection is immutable in vanilla kafka anyway
+  }
+
+  @Override
+  public Set keySet() {
+    return getMetrics().keySet();
+  }
+
+  @Override
+  public Collection values() {
+    return getMetrics().values();
+  }
+
+  @Override
+  public Set entrySet() {
+    return getMetrics().entrySet();
+  }
+}

--- a/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/consumer/LiKafkaInstrumentedConsumerImpl.java
+++ b/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/consumer/LiKafkaInstrumentedConsumerImpl.java
@@ -1,0 +1,789 @@
+/*
+ * Copyright 2019 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License").  See License in the project root for license information.
+ */
+
+package com.linkedin.kafka.clients.consumer;
+
+import com.linkedin.kafka.clients.common.MetricsProxy;
+import com.linkedin.kafka.clients.utils.LiKafkaClientsUtils;
+import com.linkedin.mario.client.EventHandler;
+import com.linkedin.mario.client.SimpleClient;
+import com.linkedin.mario.client.SimpleClientState;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Properties;
+import java.util.Set;
+import java.util.StringJoiner;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.function.Function;
+import java.util.regex.Pattern;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.clients.consumer.OffsetAndTimestamp;
+import org.apache.kafka.clients.consumer.OffsetCommitCallback;
+import org.apache.kafka.common.Metric;
+import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.PartitionInfo;
+import org.apache.kafka.common.TopicPartition;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * an instrumented consumer is a decorator around a single delegate client
+ * that supports registration with conductor, telemetry, and remote control
+ * (for example, pushing config changes from conductor side)
+ * @param <K>
+ * @param <V>
+ */
+public class LiKafkaInstrumentedConsumerImpl<K, V> implements Consumer<K, V>, EventHandler {
+  private static final Logger LOG = LoggerFactory.getLogger(LiKafkaInstrumentedConsumerImpl.class);
+
+  private final long initialConnectionTimeoutMs = TimeUnit.SECONDS.toMillis(30);
+  private final ReadWriteLock delegateLock = new ReentrantReadWriteLock();
+  private final Properties baseConfig;
+  private final Function<Properties, Consumer<K, V>> consumerFactory;
+  private final String mdsUrl;
+  private final CountDownLatch initialConnectionLatch = new CountDownLatch(1);
+  private final MetricsProxy metricsProxy = new MetricsProxy() {
+    @Override
+    protected Map<MetricName, ? extends Metric> getMetrics() {
+      Consumer<K, V> delegate = LiKafkaInstrumentedConsumerImpl.this.delegate;
+      return delegate == null ? Collections.emptyMap() : delegate.metrics();
+    }
+  };
+  private volatile Long closedAt = null;
+  private volatile Map<String, String> configOverrides = null;
+  private volatile Consumer<K, V> delegate;
+  private final SimpleClient mdsClient;
+
+  private volatile Collection<String> subscribedTopics = null;
+  private volatile ConsumerRebalanceListener rebalanceListener = null;
+  private volatile Collection<TopicPartition> assignedPartitions = null;
+  private volatile Pattern subscriptionPattern = null;
+
+  public LiKafkaInstrumentedConsumerImpl(
+      Properties baseConfig,
+      Function<Properties, Consumer<K, V>> consumerFactory,
+      String mdsUrl
+  ) {
+    List<String> conversionIssues = new ArrayList<>(1);
+    this.baseConfig = baseConfig;
+    Map<String, String> translatedBaseConfig = LiKafkaClientsUtils.propertiesToStringMap(baseConfig, conversionIssues);
+    this.consumerFactory = consumerFactory;
+    this.mdsUrl = mdsUrl;
+
+    if (!conversionIssues.isEmpty()) {
+      StringJoiner csv = new StringJoiner(", ");
+      conversionIssues.forEach(csv::add);
+      LOG.error("issues translating consumer config to strings: {}", csv);
+    }
+
+    mdsClient = new SimpleClient(
+        mdsUrl,
+        TimeUnit.MINUTES.toMillis(1),
+        TimeUnit.HOURS.toMillis(1), translatedBaseConfig,
+        this
+    );
+
+    boolean tryFallback;
+    Exception issue = null;
+    try {
+      tryFallback = !initialConnectionLatch.await(initialConnectionTimeoutMs, TimeUnit.MILLISECONDS);
+    } catch (Exception e) {
+      tryFallback = true;
+      issue = e;
+    }
+
+    if (tryFallback) {
+      boolean delegateChanged = recreateDelegate(true);
+      if (delegateChanged) {
+        if (issue != null) {
+          LOG.error("exception waiting to contact {}, using user-provided configs as fallback", mdsUrl, issue);
+        } else {
+          LOG.error("unable to contact {} within timeout ({}), using user-provided configs as fallback", mdsUrl, initialConnectionTimeoutMs);
+        }
+      } else if (issue != null) {
+        //we got interrupted waiting, but apparently connection to mds was successful?
+        LOG.warn("exception waiting on MDS connection, yet connection succeeded?", issue);
+      }
+    }
+  }
+
+  @Override
+  public void stateChanged(SimpleClient client, SimpleClientState oldState, SimpleClientState newState) {
+    if (newState == SimpleClientState.REGISTERED) {
+      try {
+        Map<String, String> newOverrides = client.getConfigOverrides();
+        Map<String, String> currentOverrides = this.configOverrides;
+        boolean configOverrideChanged = !Objects.equals(currentOverrides, newOverrides);
+        if (delegate == null || configOverrideChanged) {
+          if (configOverrideChanged) {
+            LOG.info("got new config overrides from {}: {}", mdsUrl, newOverrides);
+          } else {
+            LOG.info("successfully connected to {}, no config overrides", mdsUrl);
+          }
+          this.configOverrides = newOverrides;
+          recreateDelegate(false);
+        }
+      } finally {
+        initialConnectionLatch.countDown();
+      }
+    }
+  }
+
+  @Override
+  public void configChangeRequested(UUID commandId, Map<String, String> configDiff, String message) {
+    Map<String, String> currentOverrides = this.configOverrides;
+    if (!Objects.equals(currentOverrides, configDiff)) {
+      LOG.info("got new config overrides from {}: {} ({})", mdsUrl, configDiff, message);
+      this.configOverrides = configDiff;
+      recreateDelegate(false);
+    }
+    //TODO - respond to command UUID
+  }
+
+  //package-private FOR TESTING
+  Consumer<K, V> getDelegate() {
+    return delegate;
+  }
+
+  /**
+   * close any existing delegate client and create a new one based on the
+   * latest config overrides
+   * @param abortIfExists abort the operation if current delegate is not null
+   * @return true if delegate client actually replaced
+   */
+  private boolean recreateDelegate(boolean abortIfExists) {
+    delegateLock.writeLock().lock();
+    try {
+      Set<TopicPartition> pausedPartitions = null;
+      Consumer<K, V> prevConsumer = delegate;
+      if (prevConsumer != null) {
+        if (abortIfExists) {
+          return false; //leave existing delegate as-is
+        }
+        pausedPartitions = prevConsumer.paused();
+        delegate = null;
+        try {
+          try {
+            prevConsumer.commitSync(Duration.ofSeconds(30));
+          } finally {
+            prevConsumer.close(Duration.ofSeconds(10));
+          }
+        } catch (Exception e) {
+          LOG.error("error closing old delegate consumer", e);
+        }
+      }
+      Properties delegateConfig = new Properties();
+      delegateConfig.putAll(baseConfig);
+      if (configOverrides != null) {
+        delegateConfig.putAll(configOverrides);
+      }
+      delegate = consumerFactory.apply(delegateConfig);
+      if (subscriptionPattern != null) {
+        if (rebalanceListener != null) {
+          delegate.subscribe(subscriptionPattern, rebalanceListener);
+        } else {
+          delegate.subscribe(subscriptionPattern);
+        }
+      } else if (subscribedTopics != null) {
+        if (rebalanceListener != null) {
+          delegate.subscribe(subscribedTopics, rebalanceListener);
+        } else {
+          delegate.subscribe(subscribedTopics);
+        }
+      } else if (assignedPartitions != null) {
+        delegate.assign(assignedPartitions);
+      }
+      if (pausedPartitions != null && !pausedPartitions.isEmpty()) {
+        //TODO - this may throw exception if rebalance hasnt completed. test this
+        delegate.pause(pausedPartitions);
+      }
+      return true;
+    } finally {
+      delegateLock.writeLock().unlock();
+    }
+  }
+
+  @Override
+  public Set<TopicPartition> assignment() {
+    verifyOpen();
+
+    delegateLock.readLock().lock();
+    try {
+      return delegate.assignment();
+    } finally {
+      delegateLock.readLock().unlock();
+    }
+  }
+
+  @Override
+  public Set<String> subscription() {
+    verifyOpen();
+
+    delegateLock.readLock().lock();
+    try {
+      return delegate.subscription();
+    } finally {
+      delegateLock.readLock().unlock();
+    }
+  }
+
+  @Override
+  public void subscribe(Collection<String> topics) {
+    verifyOpen();
+
+    delegateLock.readLock().lock();
+    try {
+      subscribedTopics = topics;
+      rebalanceListener = null;
+      assignedPartitions = null;
+      subscriptionPattern = null;
+
+      delegate.subscribe(topics);
+    } finally {
+      delegateLock.readLock().unlock();
+    }
+  }
+
+  @Override
+  public void subscribe(Collection<String> topics, ConsumerRebalanceListener callback) {
+    verifyOpen();
+
+    delegateLock.readLock().lock();
+    try {
+      subscribedTopics = topics;
+      rebalanceListener = callback;
+      assignedPartitions = null;
+      subscriptionPattern = null;
+
+      delegate.subscribe(topics, callback);
+    } finally {
+      delegateLock.readLock().unlock();
+    }
+  }
+
+  @Override
+  public void assign(Collection<TopicPartition> partitions) {
+    verifyOpen();
+
+    delegateLock.readLock().lock();
+    try {
+      subscribedTopics = null;
+      rebalanceListener = null;
+      assignedPartitions = partitions;
+      subscriptionPattern = null;
+
+      delegate.assign(partitions);
+    } finally {
+      delegateLock.readLock().unlock();
+    }
+  }
+
+  @Override
+  public void subscribe(Pattern pattern, ConsumerRebalanceListener callback) {
+    verifyOpen();
+
+    delegateLock.readLock().lock();
+    try {
+      subscribedTopics = null;
+      rebalanceListener = callback;
+      assignedPartitions = null;
+      subscriptionPattern = pattern;
+
+      delegate.subscribe(pattern, callback);
+    } finally {
+      delegateLock.readLock().unlock();
+    }
+  }
+
+  @Override
+  public void subscribe(Pattern pattern) {
+    verifyOpen();
+
+    delegateLock.readLock().lock();
+    try {
+      subscribedTopics = null;
+      rebalanceListener = null;
+      assignedPartitions = null;
+      subscriptionPattern = pattern;
+
+      delegate.subscribe(pattern);
+    } finally {
+      delegateLock.readLock().unlock();
+    }
+  }
+
+  @Override
+  public void unsubscribe() {
+    verifyOpen();
+
+    delegateLock.readLock().lock();
+    try {
+      subscribedTopics = null;
+      rebalanceListener = null;
+      assignedPartitions = null;
+      subscriptionPattern = null;
+
+      delegate.unsubscribe();
+    } finally {
+      delegateLock.readLock().unlock();
+    }
+  }
+
+  @Override
+  @Deprecated
+  public ConsumerRecords<K, V> poll(long timeout) {
+    verifyOpen();
+
+    delegateLock.readLock().lock();
+    try {
+      return delegate.poll(timeout);
+    } finally {
+      delegateLock.readLock().unlock();
+    }
+  }
+
+  @Override
+  public ConsumerRecords<K, V> poll(Duration timeout) {
+    verifyOpen();
+
+    delegateLock.readLock().lock();
+    try {
+      return delegate.poll(timeout);
+    } finally {
+      delegateLock.readLock().unlock();
+    }
+  }
+
+  @Override
+  public void commitSync() {
+    verifyOpen();
+
+    delegateLock.readLock().lock();
+    try {
+      delegate.commitSync();
+    } finally {
+      delegateLock.readLock().unlock();
+    }
+  }
+
+  @Override
+  public void commitSync(Duration timeout) {
+    verifyOpen();
+
+    delegateLock.readLock().lock();
+    try {
+      delegate.commitSync(timeout);
+    } finally {
+      delegateLock.readLock().unlock();
+    }
+  }
+
+  @Override
+  public void commitSync(Map<TopicPartition, OffsetAndMetadata> offsets) {
+    verifyOpen();
+
+    delegateLock.readLock().lock();
+    try {
+      delegate.commitSync(offsets);
+    } finally {
+      delegateLock.readLock().unlock();
+    }
+  }
+
+  @Override
+  public void commitSync(Map<TopicPartition, OffsetAndMetadata> offsets, Duration timeout) {
+    verifyOpen();
+
+    delegateLock.readLock().lock();
+    try {
+      delegate.commitSync(offsets, timeout);
+    } finally {
+      delegateLock.readLock().unlock();
+    }
+  }
+
+  @Override
+  public void commitAsync() {
+    verifyOpen();
+
+    delegateLock.readLock().lock();
+    try {
+      delegate.commitAsync();
+    } finally {
+      delegateLock.readLock().unlock();
+    }
+  }
+
+  @Override
+  public void commitAsync(OffsetCommitCallback callback) {
+    verifyOpen();
+
+    delegateLock.readLock().lock();
+    try {
+      delegate.commitAsync(callback);
+    } finally {
+      delegateLock.readLock().unlock();
+    }
+  }
+
+  @Override
+  public void commitAsync(Map<TopicPartition, OffsetAndMetadata> offsets, OffsetCommitCallback callback) {
+    verifyOpen();
+
+    delegateLock.readLock().lock();
+    try {
+      delegate.commitAsync(offsets, callback);
+    } finally {
+      delegateLock.readLock().unlock();
+    }
+  }
+
+  @Override
+  public void seek(TopicPartition partition, long offset) {
+    verifyOpen();
+
+    delegateLock.readLock().lock();
+    try {
+      delegate.seek(partition, offset);
+    } finally {
+      delegateLock.readLock().unlock();
+    }
+  }
+
+  @Override
+  public void seekToBeginning(Collection<TopicPartition> partitions) {
+    verifyOpen();
+
+    delegateLock.readLock().lock();
+    try {
+      delegate.seekToBeginning(partitions);
+    } finally {
+      delegateLock.readLock().unlock();
+    }
+  }
+
+  @Override
+  public void seekToEnd(Collection<TopicPartition> partitions) {
+    verifyOpen();
+
+    delegateLock.readLock().lock();
+    try {
+      delegate.seekToEnd(partitions);
+    } finally {
+      delegateLock.readLock().unlock();
+    }
+  }
+
+  @Override
+  public long position(TopicPartition partition) {
+    verifyOpen();
+
+    delegateLock.readLock().lock();
+    try {
+      return delegate.position(partition);
+    } finally {
+      delegateLock.readLock().unlock();
+    }
+  }
+
+  @Override
+  public long position(TopicPartition partition, Duration timeout) {
+    verifyOpen();
+
+    delegateLock.readLock().lock();
+    try {
+      return delegate.position(partition, timeout);
+    } finally {
+      delegateLock.readLock().unlock();
+    }
+  }
+
+  @Override
+  public OffsetAndMetadata committed(TopicPartition partition) {
+    verifyOpen();
+
+    delegateLock.readLock().lock();
+    try {
+      return delegate.committed(partition);
+    } finally {
+      delegateLock.readLock().unlock();
+    }
+  }
+
+  @Override
+  public OffsetAndMetadata committed(TopicPartition partition, Duration timeout) {
+    verifyOpen();
+
+    delegateLock.readLock().lock();
+    try {
+      return delegate.committed(partition, timeout);
+    } finally {
+      delegateLock.readLock().unlock();
+    }
+  }
+
+  @Override
+  public Map<MetricName, ? extends Metric> metrics() {
+    //noinspection unchecked
+    return (Map<MetricName, ? extends Metric>) metricsProxy;
+  }
+
+  @Override
+  public List<PartitionInfo> partitionsFor(String topic) {
+    verifyOpen();
+
+    delegateLock.readLock().lock();
+    try {
+      return delegate.partitionsFor(topic);
+    } finally {
+      delegateLock.readLock().unlock();
+    }
+  }
+
+  @Override
+  public List<PartitionInfo> partitionsFor(String topic, Duration timeout) {
+    verifyOpen();
+
+    delegateLock.readLock().lock();
+    try {
+      return delegate.partitionsFor(topic, timeout);
+    } finally {
+      delegateLock.readLock().unlock();
+    }
+  }
+
+  @Override
+  public Map<String, List<PartitionInfo>> listTopics() {
+    verifyOpen();
+
+    delegateLock.readLock().lock();
+    try {
+      return delegate.listTopics();
+    } finally {
+      delegateLock.readLock().unlock();
+    }
+  }
+
+  @Override
+  public Map<String, List<PartitionInfo>> listTopics(Duration timeout) {
+    verifyOpen();
+
+    delegateLock.readLock().lock();
+    try {
+      return delegate.listTopics(timeout);
+    } finally {
+      delegateLock.readLock().unlock();
+    }
+  }
+
+  @Override
+  public Set<TopicPartition> paused() {
+    verifyOpen();
+
+    delegateLock.readLock().lock();
+    try {
+      return delegate.paused();
+    } finally {
+      delegateLock.readLock().unlock();
+    }
+  }
+
+  @Override
+  public void pause(Collection<TopicPartition> partitions) {
+    verifyOpen();
+
+    delegateLock.readLock().lock();
+    try {
+      delegate.pause(partitions);
+    } finally {
+      delegateLock.readLock().unlock();
+    }
+  }
+
+  @Override
+  public void resume(Collection<TopicPartition> partitions) {
+    verifyOpen();
+
+    delegateLock.readLock().lock();
+    try {
+      delegate.resume(partitions);
+    } finally {
+      delegateLock.readLock().unlock();
+    }
+  }
+
+  @Override
+  public Map<TopicPartition, OffsetAndTimestamp> offsetsForTimes(Map<TopicPartition, Long> timestampsToSearch) {
+    verifyOpen();
+
+    delegateLock.readLock().lock();
+    try {
+      return delegate.offsetsForTimes(timestampsToSearch);
+    } finally {
+      delegateLock.readLock().unlock();
+    }
+  }
+
+  @Override
+  public Map<TopicPartition, OffsetAndTimestamp> offsetsForTimes(Map<TopicPartition, Long> timestampsToSearch,
+      Duration timeout) {
+    verifyOpen();
+
+    delegateLock.readLock().lock();
+    try {
+      return delegate.offsetsForTimes(timestampsToSearch, timeout);
+    } finally {
+      delegateLock.readLock().unlock();
+    }
+  }
+
+  @Override
+  public Map<TopicPartition, Long> beginningOffsets(Collection<TopicPartition> partitions) {
+    verifyOpen();
+
+    delegateLock.readLock().lock();
+    try {
+      return delegate.beginningOffsets(partitions);
+    } finally {
+      delegateLock.readLock().unlock();
+    }
+  }
+
+  @Override
+  public Map<TopicPartition, Long> beginningOffsets(Collection<TopicPartition> partitions, Duration timeout) {
+    verifyOpen();
+
+    delegateLock.readLock().lock();
+    try {
+      return delegate.beginningOffsets(partitions, timeout);
+    } finally {
+      delegateLock.readLock().unlock();
+    }
+  }
+
+  @Override
+  public Map<TopicPartition, Long> endOffsets(Collection<TopicPartition> partitions) {
+    verifyOpen();
+
+    delegateLock.readLock().lock();
+    try {
+      return delegate.endOffsets(partitions);
+    } finally {
+      delegateLock.readLock().unlock();
+    }
+  }
+
+  @Override
+  public Map<TopicPartition, Long> endOffsets(Collection<TopicPartition> partitions, Duration timeout) {
+    verifyOpen();
+
+    delegateLock.readLock().lock();
+    try {
+      return delegate.endOffsets(partitions, timeout);
+    } finally {
+      delegateLock.readLock().unlock();
+    }
+  }
+
+  @Override
+  public void close() {
+    if (!proceedClosing()) {
+      return;
+    }
+    try {
+      delegate.close();
+    } finally {
+      delegate = null;
+      closeMdsClient();
+    }
+  }
+
+  @Override
+  @Deprecated
+  public void close(long timeout, TimeUnit unit) {
+    if (!proceedClosing()) {
+      return;
+    }
+    try {
+      delegate.close(timeout, unit);
+    } finally {
+      delegate = null;
+      closeMdsClient();
+    }
+  }
+
+  @Override
+  public void close(Duration timeout) {
+    if (!proceedClosing()) {
+      return;
+    }
+    try {
+      delegate.close(timeout);
+    } finally {
+      delegate = null;
+      closeMdsClient();
+    }
+  }
+
+  @Override
+  public void wakeup() {
+    //vanilla allows this even if closed
+    Consumer<K, V> delegate = this.delegate;
+    if (delegate != null) {
+      delegate.wakeup();
+    }
+  }
+
+  private boolean proceedClosing() {
+    if (isClosed()) {
+      return false;
+    }
+    delegateLock.writeLock().lock();
+    try {
+      if (isClosed()) {
+        return false;
+      }
+      closedAt = System.currentTimeMillis();
+      return true;
+    } finally {
+      delegateLock.writeLock().unlock();
+    }
+  }
+
+  private void closeMdsClient() {
+    try {
+      mdsClient.close();
+    } catch (Exception e) {
+      LOG.warn("error closing conductor client", e);
+    }
+  }
+
+  private boolean isClosed() {
+    return closedAt != null;
+  }
+
+  /**
+   * throws an exception if this consumer has been closed.
+   * there's also an assumption that unless closed, delegate is always != null
+   */
+  private void verifyOpen() {
+    if (isClosed()) {
+      //same exception thats thrown by a vanilla consumer
+      throw new IllegalStateException("This consumer has already been closed.");
+    }
+  }
+}

--- a/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/producer/LiKafkaInstrumentedProducerImpl.java
+++ b/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/producer/LiKafkaInstrumentedProducerImpl.java
@@ -1,0 +1,379 @@
+/*
+ * Copyright 2019 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License").  See License in the project root for license information.
+ */
+
+package com.linkedin.kafka.clients.producer;
+
+import com.linkedin.kafka.clients.common.MetricsProxy;
+import com.linkedin.kafka.clients.utils.LiKafkaClientsUtils;
+import com.linkedin.mario.client.EventHandler;
+import com.linkedin.mario.client.SimpleClient;
+import com.linkedin.mario.client.SimpleClientState;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Properties;
+import java.util.StringJoiner;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.function.Function;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.clients.producer.Callback;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.common.Metric;
+import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.PartitionInfo;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.ProducerFencedException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * an instrumented producer is a decorator around a single delegate client
+ * that supports registration with conductor, telemetry, and remote control
+ * (for example, pushing config changes from conductor side)
+ * @param <K>
+ * @param <V>
+ */
+public class LiKafkaInstrumentedProducerImpl<K, V> implements Producer<K, V>, EventHandler {
+  private static final Logger LOG = LoggerFactory.getLogger(LiKafkaInstrumentedProducerImpl.class);
+
+  private final long initialConnectionTimeoutMs = TimeUnit.SECONDS.toMillis(30);
+  private final ReadWriteLock delegateLock = new ReentrantReadWriteLock();
+  private final Properties baseConfig;
+  private final Function<Properties, Producer<K, V>> producerFactory;
+  private final String mdsUrl;
+  private final CountDownLatch initialConnectionLatch = new CountDownLatch(1);
+  private final MetricsProxy metricsProxy = new MetricsProxy() {
+    @Override
+    protected Map<MetricName, ? extends Metric> getMetrics() {
+      Producer<K, V> delegate = LiKafkaInstrumentedProducerImpl.this.delegate;
+      return delegate == null ? Collections.emptyMap() : delegate.metrics();
+    }
+  };
+  private volatile Long closedAt = null;
+  private volatile Map<String, String> configOverrides;
+  private volatile Producer<K, V> delegate;
+  private final SimpleClient mdsClient;
+
+  public LiKafkaInstrumentedProducerImpl(
+      Properties baseConfig,
+      Function<Properties, Producer<K, V>> producerFactory,
+      String mdsUrl
+  ) {
+    List<String> conversionIssues = new ArrayList<>(1);
+    this.baseConfig = baseConfig;
+    Map<String, String> translatedBaseConfig = LiKafkaClientsUtils.propertiesToStringMap(baseConfig, conversionIssues);
+    this.producerFactory = producerFactory;
+    this.mdsUrl = mdsUrl;
+
+    if (!conversionIssues.isEmpty()) {
+      StringJoiner csv = new StringJoiner(", ");
+      conversionIssues.forEach(csv::add);
+      LOG.error("issues translating producer config to strings: {}", csv);
+    }
+
+    mdsClient = new SimpleClient(
+        mdsUrl,
+        TimeUnit.MINUTES.toMillis(1),
+        TimeUnit.HOURS.toMillis(1), translatedBaseConfig,
+        this
+    );
+
+    boolean tryFallback;
+    Exception issue = null;
+    try {
+      tryFallback = !initialConnectionLatch.await(initialConnectionTimeoutMs, TimeUnit.MILLISECONDS);
+    } catch (Exception e) {
+      tryFallback = true;
+      issue = e;
+    }
+
+    if (tryFallback) {
+      boolean delegateChanged = recreateDelegate(true);
+      if (delegateChanged) {
+        if (issue != null) {
+          LOG.error("exception waiting to contact {}, using user-provided configs as fallback", mdsUrl, issue);
+        } else {
+          LOG.error("unable to contact {} within timeout ({}), using user-provided configs as fallback", mdsUrl, initialConnectionTimeoutMs);
+        }
+      } else if (issue != null) {
+        //we got interrupted waiting, but apparently connection to mds was successful?
+        LOG.warn("exception waiting on MDS connection, yet connection succeeded?", issue);
+      }
+    }
+  }
+
+  @Override
+  public void stateChanged(SimpleClient client, SimpleClientState oldState, SimpleClientState newState) {
+    if (newState == SimpleClientState.REGISTERED) {
+      try {
+        Map<String, String> newOverrides = client.getConfigOverrides();
+        Map<String, String> currentOverrides = this.configOverrides;
+        boolean configOverrideChanged = !Objects.equals(currentOverrides, newOverrides);
+        if (delegate == null || configOverrideChanged) {
+          if (configOverrideChanged) {
+            LOG.info("got new config overrides from {}: {}", mdsUrl, newOverrides);
+          } else {
+            LOG.info("successfully connected to {}, no config overrides", mdsUrl);
+          }
+          this.configOverrides = newOverrides;
+          recreateDelegate(false);
+        }
+      } finally {
+        initialConnectionLatch.countDown();
+      }
+    }
+  }
+
+  @Override
+  public void configChangeRequested(UUID commandId, Map<String, String> configDiff, String message) {
+    Map<String, String> currentOverrides = this.configOverrides;
+    if (!Objects.equals(currentOverrides, configDiff)) {
+      LOG.info("got new config overrides from {}: {} ({})", mdsUrl, configDiff, message);
+      this.configOverrides = configDiff;
+      recreateDelegate(false);
+    }
+    //TODO - respond to command UUID
+  }
+
+  //package-private FOR TESTING
+  Producer<K, V> getDelegate() {
+    return delegate;
+  }
+
+  /**
+   * close any existing delegate client and create a new one based on the
+   * latest config overrides
+   * @param abortIfExists abort the operation if current delegate is not null
+   * @return true if delegate client actually replaced
+   */
+  private boolean recreateDelegate(boolean abortIfExists) {
+    delegateLock.writeLock().lock();
+    try {
+      Producer<K, V> prevProducer = delegate;
+      if (prevProducer != null) {
+        if (abortIfExists) {
+          return false; //leave existing delegate as-is
+        }
+        delegate = null;
+        try {
+          try {
+            prevProducer.flush();
+          } finally {
+            //TODO - fix back after bumping up kafka-clients
+            prevProducer.close(10, TimeUnit.SECONDS);
+          }
+        } catch (Exception e) {
+          LOG.error("error closing old delegate producer", e);
+        }
+        //TODO - keep track of ongoing transactions, and cancel them?
+        //(not sure, need to see transaction spec)
+      }
+      Properties delegateConfig = new Properties();
+      delegateConfig.putAll(baseConfig);
+      if (configOverrides != null) {
+        delegateConfig.putAll(configOverrides);
+      }
+      delegate = producerFactory.apply(delegateConfig);
+      return true;
+    } finally {
+      delegateLock.writeLock().unlock();
+    }
+  }
+
+  @Override
+  public void initTransactions() {
+    verifyOpen();
+
+    delegateLock.readLock().lock();
+    try {
+      delegate.initTransactions();
+    } finally {
+      delegateLock.readLock().unlock();
+    }
+  }
+
+  @Override
+  public void beginTransaction() throws ProducerFencedException {
+    verifyOpen();
+
+    delegateLock.readLock().lock();
+    try {
+      delegate.beginTransaction();
+    } finally {
+      delegateLock.readLock().unlock();
+    }
+  }
+
+  @Override
+  public void sendOffsetsToTransaction(Map<TopicPartition, OffsetAndMetadata> offsets, String consumerGroupId) throws ProducerFencedException {
+    verifyOpen();
+
+    delegateLock.readLock().lock();
+    try {
+      delegate.sendOffsetsToTransaction(offsets, consumerGroupId);
+    } finally {
+      delegateLock.readLock().unlock();
+    }
+  }
+
+  @Override
+  public void commitTransaction() throws ProducerFencedException {
+    verifyOpen();
+
+    delegateLock.readLock().lock();
+    try {
+      delegate.commitTransaction();
+    } finally {
+      delegateLock.readLock().unlock();
+    }
+  }
+
+  @Override
+  public void abortTransaction() throws ProducerFencedException {
+    verifyOpen();
+
+    delegateLock.readLock().lock();
+    try {
+      delegate.abortTransaction();
+    } finally {
+      delegateLock.readLock().unlock();
+    }
+  }
+
+  @Override
+  public Future<RecordMetadata> send(ProducerRecord<K, V> record) {
+    verifyOpen();
+
+    delegateLock.readLock().lock();
+    try {
+      return delegate.send(record);
+    } finally {
+      delegateLock.readLock().unlock();
+    }
+  }
+
+  @Override
+  public Future<RecordMetadata> send(ProducerRecord<K, V> record, Callback callback) {
+    verifyOpen();
+
+    delegateLock.readLock().lock();
+    try {
+      return delegate.send(record, callback);
+    } finally {
+      delegateLock.readLock().unlock();
+    }
+  }
+
+  @Override
+  public void flush() {
+    verifyOpen();
+
+    delegateLock.readLock().lock();
+    try {
+      delegate.flush();
+    } finally {
+      delegateLock.readLock().unlock();
+    }
+  }
+
+  @Override
+  public List<PartitionInfo> partitionsFor(String topic) {
+    verifyOpen();
+
+    delegateLock.readLock().lock();
+    try {
+      return delegate.partitionsFor(topic);
+    } finally {
+      delegateLock.readLock().unlock();
+    }
+  }
+
+  @Override
+  public Map<MetricName, ? extends Metric> metrics() {
+    //noinspection unchecked
+    return (Map<MetricName, ? extends Metric>) metricsProxy;
+  }
+
+  @Override
+  public void close() {
+    if (!proceedClosing()) {
+      return;
+    }
+    try {
+      delegate.close();
+    } finally {
+      delegate = null;
+      closeMdsClient();
+    }
+  }
+
+  //TODO - remove after bumping up kafka-clients
+  @Override
+  public void close(long timeout, TimeUnit unit) {
+    close(Duration.ofMillis(unit.toMillis(timeout)));
+  }
+
+  //@Override
+  public void close(Duration timeout) {
+    if (!proceedClosing()) {
+      return;
+    }
+    try {
+      //TODO - fix back after bumping up kafka
+      delegate.close(timeout.toMillis(), TimeUnit.MILLISECONDS);
+    } finally {
+      delegate = null;
+      closeMdsClient();
+    }
+  }
+
+  private boolean proceedClosing() {
+    if (isClosed()) {
+      return false;
+    }
+    delegateLock.writeLock().lock();
+    try {
+      if (isClosed()) {
+        return false;
+      }
+      closedAt = System.currentTimeMillis();
+      return true;
+    } finally {
+      delegateLock.writeLock().unlock();
+    }
+  }
+
+  private void closeMdsClient() {
+    try {
+      mdsClient.close();
+    } catch (Exception e) {
+      LOG.warn("error closing conductor client", e);
+    }
+  }
+
+  private boolean isClosed() {
+    return closedAt != null;
+  }
+
+  /**
+   * throws an exception if this producer has been closed.
+   * there's also an assumption that unless closed, delegate is always != null
+   */
+  private void verifyOpen() {
+    if (isClosed()) {
+      //same exception thats thrown by a vanilla producer
+      throw new IllegalStateException("Cannot perform operation after producer has been closed");
+    }
+  }
+}

--- a/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/utils/LiKafkaClientsUtils.java
+++ b/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/utils/LiKafkaClientsUtils.java
@@ -7,6 +7,11 @@ package com.linkedin.kafka.clients.utils;
 import java.nio.ByteBuffer;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
 import java.util.Set;
 import java.util.UUID;
 
@@ -100,5 +105,25 @@ public class LiKafkaClientsUtils {
         t.dumpStack();
       }
     }
+  }
+
+  public static Map<String, String> propertiesToStringMap(Properties props, List<String> errors) {
+    if (props == null) {
+      return null;
+    }
+    if (props.isEmpty()) {
+      return Collections.emptyMap();
+    }
+    Map<String, String> translated = new HashMap<>(props.size());
+    props.forEach((k, v) -> {
+      //Properties does not allow for null keys or values
+      String sk = k.toString();
+      String sv = v.toString();
+      String other = translated.put(sk, sv);
+      if (other != null && errors != null) {
+        errors.add("value " + sk + "=" + sv + " clobbers over value " + other + " after string conversion");
+      }
+    });
+    return translated;
   }
 }


### PR DESCRIPTION
this PR adds "instrumented" kafka clients - these are decorators around kafka clients that maintain a connection to a MDS (conductor) and are capable of basic "remote control" - currently only config overrides.