### PR TITLE
Removing partitionsFor API that has no implementation 

### DIFF
--- a/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/producer/LiKafkaFederatedProducerImpl.java
+++ b/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/producer/LiKafkaFederatedProducerImpl.java
@@ -11,9 +11,7 @@ import com.linkedin.kafka.clients.common.LiKafkaFederatedClientType;
 import com.linkedin.kafka.clients.metadataservice.MetadataServiceClient;
 import com.linkedin.kafka.clients.metadataservice.MetadataServiceClientException;
 import com.linkedin.kafka.clients.utils.LiKafkaClientsUtils;
-
 import com.linkedin.mario.common.websockets.MessageType;
-
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -22,17 +20,16 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.UUID;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
-
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.producer.Callback;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
-import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.Metric;
 import org.apache.kafka.common.MetricName;
@@ -220,12 +217,6 @@ public class LiKafkaFederatedProducerImpl<K, V> implements LiKafkaProducer<K, V>
   @Override
   synchronized public List<PartitionInfo> partitionsFor(String topic) {
     return getOrCreateProducerForTopic(topic).partitionsFor(topic);
-  }
-
-  @Override
-  synchronized public Map<String, List<PartitionInfo>> partitionsFor(Set<String> topics) {
-    // TODO: come back here when upstream API settles
-    throw new UnsupportedOperationException("Not implemented yet");
   }
 
   @Override

--- a/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/producer/LiKafkaProducer.java
+++ b/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/producer/LiKafkaProducer.java
@@ -6,10 +6,6 @@ package com.linkedin.kafka.clients.producer;
 
 import com.linkedin.kafka.clients.annotations.InterfaceOrigin;
 import java.util.concurrent.TimeUnit;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.clients.producer.Producer;
 
 
@@ -27,7 +23,4 @@ public interface LiKafkaProducer<K, V> extends Producer<K, V> {
    */
   @InterfaceOrigin.LiKafkaClients
   void flush(long timeout, TimeUnit timeUnit);
-
-  @InterfaceOrigin.LiKafkaClients
-  Map<String, List<PartitionInfo>> partitionsFor(Set<String> topics);
 }

--- a/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/producer/LiKafkaProducerImpl.java
+++ b/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/producer/LiKafkaProducerImpl.java
@@ -13,15 +13,21 @@ import com.linkedin.kafka.clients.largemessage.MessageSplitterImpl;
 import com.linkedin.kafka.clients.largemessage.errors.SkippableException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.util.Set;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.producer.Callback;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
-import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.Metric;
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.PartitionInfo;
@@ -33,14 +39,6 @@ import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.apache.kafka.common.serialization.Serializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
-import java.util.UUID;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * This producer is the implementation of {@link LiKafkaProducer}.
@@ -360,12 +358,6 @@ public class LiKafkaProducerImpl<K, V> implements LiKafkaProducer<K, V> {
   @Override
   public List<PartitionInfo> partitionsFor(String topic) {
     return _producer.partitionsFor(topic);
-  }
-
-  @Override
-  public Map<String, List<PartitionInfo>> partitionsFor(Set<String> topics) {
-    //TODO come back here when upstream API settles
-    throw new UnsupportedOperationException("not implemented");
   }
 
   @Override

--- a/li-apache-kafka-clients/src/test/java/com/linkedin/kafka/clients/producer/MockLiKafkaProducer.java
+++ b/li-apache-kafka-clients/src/test/java/com/linkedin/kafka/clients/producer/MockLiKafkaProducer.java
@@ -6,7 +6,6 @@ package com.linkedin.kafka.clients.producer;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
@@ -55,12 +54,6 @@ public class MockLiKafkaProducer implements LiKafkaProducer<byte[], byte[]> {
   @Override
   public List<PartitionInfo> partitionsFor(String topic) {
     return _delegate.partitionsFor(topic);
-  }
-
-  @Override
-  public Map<String, List<PartitionInfo>> partitionsFor(Set<String> topics) {
-    //TODO come back here when upstream API settles
-    throw new UnsupportedOperationException("not implemented");
   }
 
   @Override


### PR DESCRIPTION
There is `partitionFor` API override in `LiKafkaProducer` interface that accepts a `Set` of topic names as an argument. It is however, not implemented in anywhere. 
* I also verified the internal LinkedIn specific implementations. 
* I don't see the API in Apache Kafka. So, the `TODO` comment near the API definition doesn't make sense. 
