### PR TITLE
Add the bounded flush implementation to LiKafkaInstrumentedProducer

### DIFF
--- a/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/producer/LiKafkaInstrumentedProducerImpl.java
+++ b/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/producer/LiKafkaInstrumentedProducerImpl.java
@@ -325,8 +325,7 @@ public class LiKafkaInstrumentedProducerImpl<K, V> implements Producer<K, V>, Ev
         try {
           boundedFlushMethod.invoke(delegate, timeout, timeUnit);
         } catch (IllegalAccessException | InvocationTargetException e) {
-          LOG.trace("Underlying producer does not support bounded flush!", e);
-          useSeparateThreadForFlush = true;
+          throw new IllegalStateException("failed to invoke the bounded flush method", e);
         }
       } else {
         useSeparateThreadForFlush = true;

--- a/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/producer/LiKafkaProducerImpl.java
+++ b/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/producer/LiKafkaProducerImpl.java
@@ -323,8 +323,7 @@ public class LiKafkaProducerImpl<K, V> implements LiKafkaProducer<K, V> {
       try {
         _boundedFlushMethod.invoke(_producer, timeout, timeUnit);
       } catch (IllegalAccessException | InvocationTargetException e) {
-        LOG.trace("Underlying producer does not support bounded flush!", e);
-        useSeparateThreadForFlush = true;
+        throw new IllegalStateException("failed to invoke the bounded flush method", e);
       }
     } else {
       useSeparateThreadForFlush = true;


### PR DESCRIPTION
This is temporary until KAFKA-7711 is fixed in upstream.