### PR TITLE
introduce interfaces for delegating clients, use them in instrumented clients

### DIFF
--- a/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/consumer/DelegatingConsumer.java
+++ b/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/consumer/DelegatingConsumer.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright 2019 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License").  See License in the project root for license information.
+ */
+
+package com.linkedin.kafka.clients.consumer;
+
+import org.apache.kafka.clients.consumer.Consumer;
+
+
+public interface DelegatingConsumer<K, V> extends Consumer<K, V> {
+  Consumer<K, V> getDelegate();
+}

--- a/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/consumer/LiKafkaInstrumentedConsumerImpl.java
+++ b/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/consumer/LiKafkaInstrumentedConsumerImpl.java
@@ -47,7 +47,7 @@ import org.slf4j.LoggerFactory;
  * @param <K>
  * @param <V>
  */
-public class LiKafkaInstrumentedConsumerImpl<K, V> implements Consumer<K, V>, EventHandler {
+public class LiKafkaInstrumentedConsumerImpl<K, V> implements DelegatingConsumer<K, V>, EventHandler {
   private static final Logger LOG = LoggerFactory.getLogger(LiKafkaInstrumentedConsumerImpl.class);
 
   private final long initialConnectionTimeoutMs = TimeUnit.SECONDS.toMillis(30);
@@ -154,8 +154,8 @@ public class LiKafkaInstrumentedConsumerImpl<K, V> implements Consumer<K, V>, Ev
     //TODO - respond to command UUID
   }
 
-  //package-private FOR TESTING
-  Consumer<K, V> getDelegate() {
+  @Override
+  public Consumer<K, V> getDelegate() {
     return delegate;
   }
 

--- a/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/producer/DelegatingProducer.java
+++ b/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/producer/DelegatingProducer.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright 2019 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License").  See License in the project root for license information.
+ */
+
+package com.linkedin.kafka.clients.producer;
+
+import org.apache.kafka.clients.producer.Producer;
+
+
+public interface DelegatingProducer<K, V> extends Producer<K, V> {
+  Producer<K, V> getDelegate();
+}

--- a/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/producer/LiKafkaInstrumentedProducerImpl.java
+++ b/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/producer/LiKafkaInstrumentedProducerImpl.java
@@ -49,7 +49,7 @@ import org.slf4j.LoggerFactory;
  * @param <K>
  * @param <V>
  */
-public class LiKafkaInstrumentedProducerImpl<K, V> implements Producer<K, V>, EventHandler {
+public class LiKafkaInstrumentedProducerImpl<K, V> implements DelegatingProducer<K, V>, EventHandler {
   private static final Logger LOG = LoggerFactory.getLogger(LiKafkaInstrumentedProducerImpl.class);
   private static final String BOUNDED_FLUSH_THREAD_PREFIX = "Bounded-Flush-Thread-";
 
@@ -156,8 +156,8 @@ public class LiKafkaInstrumentedProducerImpl<K, V> implements Producer<K, V>, Ev
     //TODO - respond to command UUID
   }
 
-  //package-private FOR TESTING
-  Producer<K, V> getDelegate() {
+  @Override
+  public Producer<K, V> getDelegate() {
     return delegate;
   }
 


### PR DESCRIPTION
not expected to be widely used by end users, but being able to "traverse" a stack of decorated clients could come in handy for infra code