### PR TITLE
bump bintray library to work with newer gradle

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -15,7 +15,7 @@ dependencies {
 
   compile 'org.ajoberstar:gradle-git:1.2.0'
   compile group: 'org.apache.httpcomponents', name: 'fluent-hc', version: '4.5.2'
-  compile('org.jfrog.buildinfo:build-info-extractor-gradle:4.5.4') {
+  compile('org.jfrog.buildinfo:build-info-extractor-gradle:4.8.1') {
     exclude module: 'groovy-all'
   }
 }


### PR DESCRIPTION
see https://github.com/jfrog/build-info/issues/171

Signed-off-by: Radai Rosenblatt <rrosenbl@rrosenbl-ld2.linkedin.biz>