### PR TITLE
make instrumented consumer behave the same as vanilla consumer around concurrent poll and close

### DIFF
--- a/kafka-test-harness/src/main/java/com/linkedin/kafka/clients/utils/tests/EmbeddedBrokerBuilder.java
+++ b/kafka-test-harness/src/main/java/com/linkedin/kafka/clients/utils/tests/EmbeddedBrokerBuilder.java
@@ -214,6 +214,8 @@ public class EmbeddedBrokerBuilder {
     props.put("log.cleaner.dedupe.buffer.size", Long.toString(logCleanerDedupBufferSize));
     props.put("log.cleaner.enable", Boolean.toString(enableLogCleaner));
     props.put("offsets.topic.replication.factor", "1");
+    props.put("offsets.topic.num.partitions", "2");
+    props.put("group.initial.rebalance.delay.ms", "100");
     if (rack != null) {
       props.put("broker.rack", rack);
     }

--- a/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/utils/CloseableLock.java
+++ b/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/utils/CloseableLock.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2019 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License").  See License in the project root for license information.
+ */
+
+package com.linkedin.kafka.clients.utils;
+
+import java.util.concurrent.locks.Lock;
+
+
+/**
+ * a handy decorator around java locks that allows them to be used with try-with-resources expressions
+ */
+public class CloseableLock implements AutoCloseable {
+  private final Lock lock;
+
+  public CloseableLock(Lock lock) {
+    this.lock = lock;
+    this.lock.lock();
+  }
+
+  @Override
+  public void close() {
+    lock.unlock();
+  }
+}

--- a/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/utils/KafkaConsumerLock.java
+++ b/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/utils/KafkaConsumerLock.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2019 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License").  See License in the project root for license information.
+ */
+
+package com.linkedin.kafka.clients.utils;
+
+import java.util.ConcurrentModificationException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.Lock;
+
+
+/**
+ * a "lock" that implements kafka consumer locking semantics. <br>
+ * note that kafka consumer locking semantics are not good for general purpose locking :-)
+ */
+public class KafkaConsumerLock implements Lock {
+
+  //the thread that currently holds the lock (==is operating on the consumer). null for none
+  private AtomicReference<Thread> ownerThread = new AtomicReference<>(null);
+  //"depth" (number of times acquired) for current owner thread. this is to provide reenterance support
+  private AtomicInteger refCount = new AtomicInteger(0);
+
+  @Override
+  public void lock() {
+    if (!tryLock()) {
+      Thread owner = ownerThread.get(); //may be null if we got unscheduled. this is just best effort for logging.
+      throw new ConcurrentModificationException("KafkaConsumer is not safe for multi-threaded access. "
+          + "competing thread is " + (owner != null ? owner.getName() : "unknown"));
+    }
+  }
+
+  @Override
+  public void lockInterruptibly() throws InterruptedException {
+    throw new UnsupportedOperationException("not implemented (yet?)");
+  }
+
+  @Override
+  public boolean tryLock() {
+    Thread current = Thread.currentThread();
+    Thread owner = ownerThread.get();
+    if (owner != current && !ownerThread.compareAndSet(null, current)) {
+      //we lost
+      return false;
+    }
+    refCount.incrementAndGet();
+    return true;
+  }
+
+  @Override
+  public boolean tryLock(long time, TimeUnit unit) throws InterruptedException {
+    throw new UnsupportedOperationException("not implemented (yet?)");
+  }
+
+  @Override
+  public void unlock() {
+    if (refCount.decrementAndGet() == 0) {
+      ownerThread.set(null);
+    }
+  }
+
+  @Override
+  public Condition newCondition() {
+    throw new UnsupportedOperationException("not implemented (yet?)");
+  }
+}


### PR DESCRIPTION
note that vanilla clients would throw an exception on the thread calling close() in this case.