### PR TITLE
Log the exception as warning for Auditor during shutdown.

### DIFF
--- a/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/auditing/abstractimpl/AbstractAuditor.java
+++ b/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/auditing/abstractimpl/AbstractAuditor.java
@@ -157,7 +157,7 @@ public abstract class AbstractAuditor<K, V> extends Thread implements Auditor<K,
         try {
           onClosed(_currentStats, _nextStats, Math.max(0, shutdownBudgetRemaining));
         } catch (Exception e) {
-          LOG.error("error closing auditor", e);
+          LOG.warn("error closing auditor", e);
         }
       }
     } else {


### PR DESCRIPTION
If the timeout passed to auditingKafkaProducer#close() method is very short, it can so happen that the producer might get closed before all the audit counts are flushed raising _IllegalArgumentException_.

This change logs such exceptions during the shutdown as a warning instead of an error.