### PR TITLE
Update kafka version to 2.0.0.25

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,7 @@ project.ext {
       url "https://github.com/linkedin/li-apache-kafka-clients"
     }
   }
-  liKafkaVersion = "2.0.0.24"
+  liKafkaVersion = "2.0.0.25"
   marioVersion = "0.0.27"
 }
 


### PR DESCRIPTION
Update kafka version to 2.0.0.25 to include fix for KAFKA-8950 - KafkaConsumer stops fetching