### PR TITLE
use extended serde interface for sdc testing

### DIFF
--- a/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/largemessage/ConsumerRecordsProcessor.java
+++ b/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/largemessage/ConsumerRecordsProcessor.java
@@ -25,7 +25,6 @@ import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.ExtendedDeserializer;
-import org.apache.kafka.common.serialization.ExtendedSerializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/largemessage/ConsumerRecordsProcessor.java
+++ b/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/largemessage/ConsumerRecordsProcessor.java
@@ -85,6 +85,7 @@ public class ConsumerRecordsProcessor<K, V> {
   private final Map<TopicPartition, ConsumerHighWatermarkState> _partitionConsumerHighWatermark;
   private final Auditor<K, V> _auditor;
   private final Function<TopicPartition, ConsumerHighWatermarkState> _storedConsumerHighWatermark;
+  private final DeserializeStrategy<V> _deserializeStrategy;
 
   private long recordsSkipped = 0;
 
@@ -126,6 +127,22 @@ public class ConsumerRecordsProcessor<K, V> {
       }
       return new ConsumerHighWatermarkState(consumerHighWatermark, offsetAndMetadata.offset());
     };
+    // Performance optimization to avoid a call to instanceof for every deserialization call
+    if (_valueDeserializer instanceof ExtendedDeserializer) {
+      _deserializeStrategy = new DeserializeStrategy<V>() {
+        @Override
+        public V deserialize(String topic, Headers headers, byte[] data) {
+          return ((ExtendedDeserializer<V>) _valueDeserializer).deserialize(topic, headers, data);
+        }
+      };
+    } else {
+      _deserializeStrategy = new DeserializeStrategy<V>() {
+        @Override
+        public V deserialize(String topic, Headers headers, byte[] data) {
+          return _valueDeserializer.deserialize(topic, data);
+        }
+      };
+    }
   }
 
   /**
@@ -423,12 +440,7 @@ public class ConsumerRecordsProcessor<K, V> {
     K key = _keyDeserializer.deserialize(tp.topic(), consumerRecord.key());
     byte[] valueBytes = parseAndMaybeTrackRecord(tp, consumerRecord.offset(), consumerRecord.value());
     if (valueBytes != INCOMPLETE_RESULT) {
-      V value;
-      if (_valueDeserializer instanceof ExtendedDeserializer) {
-        value = ((ExtendedDeserializer<V>) _valueDeserializer).deserialize(tp.topic(), consumerRecord.headers(), valueBytes);
-      } else {
-        value = _valueDeserializer.deserialize(tp.topic(), valueBytes);
-      }
+      V value = (V) _deserializeStrategy.deserialize(tp.topic(), consumerRecord.headers(), valueBytes);
       if (_auditor != null) {
         long sizeInBytes = (consumerRecord.key() == null ? 0 : consumerRecord.key().length) +
             (valueBytes == null ? 0 : valueBytes.length);
@@ -527,4 +539,7 @@ public class ConsumerRecordsProcessor<K, V> {
     return hw > offset;
   }
 
+  private static interface DeserializeStrategy<V> {
+    V deserialize(String topic, Headers headers, byte[] data);
+  }
 }

--- a/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/producer/LiKafkaProducerImpl.java
+++ b/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/producer/LiKafkaProducerImpl.java
@@ -42,6 +42,7 @@ import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
+import org.apache.kafka.common.serialization.ExtendedSerializer;
 import org.apache.kafka.common.serialization.Serializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -290,7 +291,12 @@ public class LiKafkaProducerImpl<K, V> implements LiKafkaProducer<K, V> {
       byte[] serializedValue;
       byte[] serializedKey;
       try {
-        serializedValue = _valueSerializer.serialize(topic, value);
+        // ExtendedSerializer is used to test Share dictionary compression
+        if (_valueSerializer instanceof ExtendedSerializer) {
+          serializedValue = ((ExtendedSerializer<V>) _valueSerializer).serialize(topic, headers, value);
+        } else {
+          serializedValue = _valueSerializer.serialize(topic, value);
+        }
         serializedKey = _keySerializer.serialize(topic, key);
       } catch (Throwable t) {
         // Audit the attempt and the failure.

--- a/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/producer/LiKafkaProducerImpl.java
+++ b/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/producer/LiKafkaProducerImpl.java
@@ -6,7 +6,6 @@ package com.linkedin.kafka.clients.producer;
 
 import com.linkedin.kafka.clients.auditing.AuditType;
 import com.linkedin.kafka.clients.auditing.Auditor;
-import com.linkedin.kafka.clients.largemessage.ConsumerRecordsProcessor;
 import com.linkedin.kafka.clients.largemessage.LargeMessageCallback;
 import com.linkedin.kafka.clients.largemessage.LargeMessageSegment;
 import com.linkedin.kafka.clients.largemessage.MessageSplitter;


### PR DESCRIPTION
Compression/Decompression will be implemented by extending Extended{Serializer, Deserializer} interface and adding a delegate avro serializer/deserializer. So Serde with (de)compression will be passed in from "Linkedin bits" and used in the client. At produce time, we first serialize and then compress, at consume time, we first decompress then serialize.