### PR TITLE
Added a new consumer metric - consumerOffsetWatermarkSpan to represent "distance between the safe offset and watermark"

### DIFF
--- a/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/consumer/LiKafkaConsumerImpl.java
+++ b/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/consumer/LiKafkaConsumerImpl.java
@@ -148,22 +148,22 @@ public class LiKafkaConsumerImpl<K, V> implements LiKafkaConsumer<K, V> {
       }
     };
 
-    MetricName consumerSnagMetricName = new MetricName(
-        "consumer-snag",
+    MetricName consumerOffsetWatermarkSpan = new MetricName(
+        "consumer-offset-watermark-span",
         "lnkd",
-        "sum of snag distance values for all partitions, where snag distance of a partition "
+        "sum of offset-watermark-span for all partitions, where offset-watermark-span of a partition "
             + "shows how far behind the safe offset of a partition is from its watermark.",
         Collections.singletonMap("client-id", _clientId)
     );
-    Metric consumerSnagMetric = new Metric() {
+    Metric consumerOffsetWatermarkSpanMetric = new Metric() {
       @Override
       public MetricName metricName() {
-        return consumerSnagMetricName;
+        return consumerOffsetWatermarkSpan;
       }
 
       @Override
       public double value() {
-        return (double) _consumerRecordsProcessor.getConsumerSnag();
+        return (double) _consumerRecordsProcessor.getConsumerOffsetWatermarkSpan();
       }
 
       @Override
@@ -173,7 +173,7 @@ public class LiKafkaConsumerImpl<K, V> implements LiKafkaConsumer<K, V> {
     };
 
     _extraMetrics.put(skippedRecordsMetricName, skippedRecordsMetric);
-    _extraMetrics.put(consumerSnagMetricName, consumerSnagMetric);
+    _extraMetrics.put(consumerOffsetWatermarkSpan, consumerOffsetWatermarkSpanMetric);
 
     try {
 

--- a/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/consumer/LiKafkaConsumerImpl.java
+++ b/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/consumer/LiKafkaConsumerImpl.java
@@ -79,7 +79,7 @@ public class LiKafkaConsumerImpl<K, V> implements LiKafkaConsumer<K, V> {
   private final long _autoCommitInterval;
   private final LiOffsetResetStrategy _offsetResetStrategy;
   private long _lastAutoCommitMs;
-  private final Map<MetricName, Metric> _extraMetrics = new HashMap<>(1);
+  private final Map<MetricName, Metric> _extraMetrics = new HashMap<>(2);
 
   private ConsumerRecordsProcessResult<K, V> _lastProcessedResult;
 
@@ -148,7 +148,32 @@ public class LiKafkaConsumerImpl<K, V> implements LiKafkaConsumer<K, V> {
       }
     };
 
+    MetricName consumerSnagMetricName = new MetricName(
+        "consumer-snag",
+        "lnkd",
+        "sum of snag distance values for all partitions, where snag distance of a partition "
+            + "shows how far behind the safe offset of a partition is from its watermark.",
+        Collections.singletonMap("client-id", _clientId)
+    );
+    Metric consumerSnagMetric = new Metric() {
+      @Override
+      public MetricName metricName() {
+        return consumerSnagMetricName;
+      }
+
+      @Override
+      public double value() {
+        return (double) _consumerRecordsProcessor.getConsumerSnag();
+      }
+
+      @Override
+      public Object metricValue() {
+        return value();
+      }
+    };
+
     _extraMetrics.put(skippedRecordsMetricName, skippedRecordsMetric);
+    _extraMetrics.put(consumerSnagMetricName, consumerSnagMetric);
 
     try {
 

--- a/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/largemessage/ConsumerRecordsProcessor.java
+++ b/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/largemessage/ConsumerRecordsProcessor.java
@@ -12,9 +12,9 @@ import com.linkedin.kafka.clients.utils.Constants;
 import com.linkedin.kafka.clients.utils.LiKafkaClientsUtils;
 import com.linkedin.kafka.clients.utils.PrimitiveEncoderDecoder;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -110,7 +110,7 @@ public class ConsumerRecordsProcessor<K, V> {
     _valueDeserializer = valueDeserializer;
     _deliveredMessageOffsetTracker = deliveredMessageOffsetTracker;
     _auditor = auditor;
-    _partitionConsumerHighWatermark = new HashMap<>();
+    _partitionConsumerHighWatermark = new ConcurrentHashMap<>();
     if (_auditor == null) {
       LOG.info("Auditing is disabled because no auditor is defined.");
     }
@@ -444,9 +444,7 @@ public class ConsumerRecordsProcessor<K, V> {
    */
   public long getConsumerOffsetWatermarkSpan() {
     long span = 0;
-    // mem copy to avoid ConcurrentModificationException, in case known partition set changes
-    final Set<TopicPartition> knownPartitions = new HashSet<>(knownPartitions());
-    for (TopicPartition tp : knownPartitions) {
+    for (TopicPartition tp : knownPartitions()) {
       span += _deliveredMessageOffsetTracker.offsetWatermarkSpan(tp);
     }
     return span;

--- a/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/largemessage/ConsumerRecordsProcessor.java
+++ b/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/largemessage/ConsumerRecordsProcessor.java
@@ -88,14 +88,14 @@ public class ConsumerRecordsProcessor<K, V> {
 
   private long recordsSkipped = 0;
   /**
-   * Gives an idea about how far behind the safe offset of a partition is from the watermark. Hence, the snag distance
-   * for a partition is computed as (watermark minus safeoffset).
+   * Gives an idea about how far behind the safe offset of a partition is from the watermark. Hence, the
+   * offset-watermark span or a partition is computed as (watermark minus safeoffset).
    * This metric is a sum of
-   * {@link com.linkedin.kafka.clients.largemessage.DeliveredMessageOffsetTracker#partitionSnag} distances for all
+   * {@link com.linkedin.kafka.clients.largemessage.DeliveredMessageOffsetTracker#offsetWatermarkSpan} for all
    * assigned partitions that have currently undelivered large messages in the consumer. It is computed on query of
    * the metric each time and hence, stores the last known value for this metric.
    */
-  private long _consumerSnag = -1;
+  private long _consumerOffsetWatermarkSpan = -1;
 
   /**
    *
@@ -442,13 +442,13 @@ public class ConsumerRecordsProcessor<K, V> {
     return recordsSkipped;
   }
 
-  public long getConsumerSnag() {
-    long snag = 0;
+  public long getConsumerOffsetWatermarkSpan() {
+    long span = 0;
     for (TopicPartition tp : knownPartitions()) {
-      snag += _deliveredMessageOffsetTracker.partitionSnag(tp);
+      span += _deliveredMessageOffsetTracker.offsetWatermarkSpan(tp);
     }
-    _consumerSnag = snag;
-    return _consumerSnag;
+    _consumerOffsetWatermarkSpan = span;
+    return _consumerOffsetWatermarkSpan;
   }
 
   private ConsumerRecord<K, V> handleConsumerRecord(ConsumerRecord<byte[], byte[]> consumerRecord) {


### PR DESCRIPTION
In order to identify a partition "stall" due to partial large message assembly (and not due to other problems in the consumer), we are introducing a metric called "consumer offset watermark span".  For each partition, the span distance is computed as (`watermark minus safeOffset`). Consumer offset watermark span is defined as the sum of all span distance for assigned partitions that have currently undelivered large messages in the consumer. 
When the consumer is progressing with no partial large messages in buffer, its span distance should be 0 because watermark is same as safeOffset. 