### PR TITLE
Add exception.on.invalid.offset config to allow throwing exception when auto.offset.reset is set to some policy

### DIFF
--- a/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/consumer/LiKafkaConsumerConfig.java
+++ b/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/consumer/LiKafkaConsumerConfig.java
@@ -33,6 +33,7 @@ public class LiKafkaConsumerConfig extends AbstractConfig {
   public static final String MESSAGE_ASSEMBLER_EXPIRATION_OFFSET_GAP_CONFIG = "message.assembler.expiration.offset.gap";
   public static final String MAX_TRACKED_MESSAGES_PER_PARTITION_CONFIG = "max.tracked.messages.per.partition";
   public static final String EXCEPTION_ON_MESSAGE_DROPPED_CONFIG = "exception.on.message.dropped";
+  public static final String EXCEPTION_ON_INVALID_OFFSET_RESET_CONFIG = "exception.on.invalid.offset.reset";
   public static final String TREAT_BAD_SEGMENTS_AS_PAYLOAD_CONFIG = "treat.bad.segments.as.payload";
   public static final String KEY_DESERIALIZER_CLASS_CONFIG = ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG;
   public static final String VALUE_DESERIALIZER_CLASS_CONFIG = ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG;
@@ -71,6 +72,12 @@ public class LiKafkaConsumerConfig extends AbstractConfig {
   private static final String EXCEPTION_ON_MESSAGE_DROPPED_DOC = "The message assembler will drop message when buffer is " +
       "full or the incomplete message has expired. The consumer will throw a LargeMessageDroppedException if this " +
       "configuration is set to true. Otherwise the consumer will drop the message silently.";
+
+  private static final String EXCEPTION_ON_INVALID_OFFSET_RESET_DOC = "If true, even when auto.offset.reset is set to " +
+      "earliest/latest/liclosest, InvalidOffsetException will be thrown to user upon calling to poll. This is to allow " +
+      "users to properly invoke user callback upon InvalidOffsetException while handling the reset and corresponding " +
+      "large message related internal state correctly at LiKafkaConsumerImpl. In the future when large message is decoupled " +
+      "from LiKafkaConsumerImpl, this config is not needed anymore";
 
   private static final String TREAT_BAD_SEGMENTS_AS_PAYLOAD_DOC = "The message assembler will treat invalid message segments " +
       " as payload. this can be used as a last resort when some arbitrary payloads accidentally pass as a large message segment";
@@ -132,11 +139,16 @@ public class LiKafkaConsumerConfig extends AbstractConfig {
                 "false",
                 Importance.LOW,
                 EXCEPTION_ON_MESSAGE_DROPPED_DOC)
-        .define(TREAT_BAD_SEGMENTS_AS_PAYLOAD_CONFIG,
-            Type.BOOLEAN,
+        .define(EXCEPTION_ON_INVALID_OFFSET_RESET_CONFIG,
+                Type.BOOLEAN,
             "false",
-            Importance.LOW,
-            TREAT_BAD_SEGMENTS_AS_PAYLOAD_DOC)
+                Importance.LOW,
+                EXCEPTION_ON_INVALID_OFFSET_RESET_DOC)
+        .define(TREAT_BAD_SEGMENTS_AS_PAYLOAD_CONFIG,
+                Type.BOOLEAN,
+            "false",
+                Importance.LOW,
+                TREAT_BAD_SEGMENTS_AS_PAYLOAD_DOC)
         .define(KEY_DESERIALIZER_CLASS_CONFIG,
                 Type.CLASS,
                 ByteArrayDeserializer.class.getName(),


### PR DESCRIPTION
Add an exception.on.invalid.offset config to allow throw the InvalidOffsetException even when auto.offset.reset for LiKafkaConsumer is set to some policy (earliest/latest/liclosest). This is to allow users to handle this exception while let LiKafkaConsumer deal with the internal state of large message.

This is just a temporary solution and will be discarded when large message support has been refactored