### PR TITLE
Bump kafka version to include MM passthrough fix revert

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,7 @@ project.ext {
       url "https://github.com/linkedin/li-apache-kafka-clients"
     }
   }
-  liKafkaVersion = "2.0.0.25"
+  liKafkaVersion = "2.0.0.27"
   marioVersion = "0.0.34"
 }
 


### PR DESCRIPTION
Bump liKafkaVersion from 2.0.0.25 to 2.0.0.27 to include MM passthrough fix revert.

There was a patch to enable passthrough work between msg format v1 and v2, but BMM/KMM is seeing perf issues with the patch. Due to lack of snapshot debugging, we have to revert that patch to verify and unblock BMM/KMM.