### PR TITLE
Add enableRecordHeader config in producer

### DIFF
--- a/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/largemessage/MessageSplitterImpl.java
+++ b/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/largemessage/MessageSplitterImpl.java
@@ -112,24 +112,20 @@ public class MessageSplitterImpl implements MessageSplitter {
         enableRecordHeader = PrimitiveEncoderDecoder.decodeBoolean(headers.lastHeader(Constants.SHOULD_USE_HEADER).value(), 0);
       }
       byte[] segmentValue;
-      if (!enableRecordHeader) {
+      byte largeMessageHeaderValueVersion;
+      if (enableRecordHeader) {
+        segmentValue = payload.array();
+        largeMessageHeaderValueVersion = LargeMessageHeaderValue.V3;
+      } else {
         // NOTE: Even though we are passing topic here to serialize, the segment itself should be topic independent.
         segmentValue = _segmentSerializer.serialize(topic, segment);
-      } else {
-        segmentValue = payload.array();
+        largeMessageHeaderValueVersion = LargeMessageHeaderValue.LEGACY_V2;
       }
 
       //  Make a temporary copy of headers because we'd be overwriting {@link Constants.LARGE_MESSAGE_HEADER}
       Headers temporaryHeaders = new RecordHeaders(headers);
       temporaryHeaders.remove(Constants.LARGE_MESSAGE_HEADER);
 
-      byte largeMessageHeaderValueVersion;
-
-      if (!enableRecordHeader) {
-        largeMessageHeaderValueVersion = LargeMessageHeaderValue.LEGACY_V2;
-      } else {
-        largeMessageHeaderValueVersion = LargeMessageHeaderValue.V3;
-      }
       LargeMessageHeaderValue largeMessageHeaderValue = new LargeMessageHeaderValue(
           largeMessageHeaderValueVersion,
           messageId,

--- a/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/largemessage/MessageSplitterImpl.java
+++ b/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/largemessage/MessageSplitterImpl.java
@@ -29,13 +29,21 @@ public class MessageSplitterImpl implements MessageSplitter {
   private final int _maxSegmentSize;
   private final Serializer<LargeMessageSegment> _segmentSerializer;
   private final UUIDFactory _uuidFactory;
+  private final boolean _enableRecordHeader;
 
   public MessageSplitterImpl(int maxSegmentSize,
                              Serializer<LargeMessageSegment> segmentSerializer,
                              UUIDFactory uuidFactory) {
+    this(maxSegmentSize, segmentSerializer, uuidFactory, false);
+  }
+
+  public MessageSplitterImpl(int maxSegmentSize,
+      Serializer<LargeMessageSegment> segmentSerializer,
+      UUIDFactory uuidFactory, boolean enableRecordHeader) {
     _maxSegmentSize = maxSegmentSize;
     _segmentSerializer = segmentSerializer;
     _uuidFactory = uuidFactory;
+    _enableRecordHeader = enableRecordHeader;
   }
 
   @Override
@@ -107,13 +115,9 @@ public class MessageSplitterImpl implements MessageSplitter {
       LargeMessageSegment segment = new LargeMessageSegment(segmentMessageId, seq,
           numberOfSegments, messageSizeInBytes, payload);
 
-      boolean enableRecordHeader = false;
-      if (headers.lastHeader(Constants.SHOULD_USE_HEADER) != null) {
-        enableRecordHeader = PrimitiveEncoderDecoder.decodeBoolean(headers.lastHeader(Constants.SHOULD_USE_HEADER).value(), 0);
-      }
       byte[] segmentValue;
       byte largeMessageHeaderValueVersion;
-      if (enableRecordHeader) {
+      if (_enableRecordHeader) {
         segmentValue = payload.array();
         largeMessageHeaderValueVersion = LargeMessageHeaderValue.V3;
       } else {

--- a/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/largemessage/MessageSplitterImpl.java
+++ b/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/largemessage/MessageSplitterImpl.java
@@ -8,7 +8,6 @@ import com.linkedin.kafka.clients.common.LargeMessageHeaderValue;
 import com.linkedin.kafka.clients.utils.Constants;
 import com.linkedin.kafka.clients.utils.LiKafkaClientsUtils;
 import com.linkedin.kafka.clients.producer.UUIDFactory;
-import com.linkedin.kafka.clients.utils.PrimitiveEncoderDecoder;
 import java.util.Collections;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.header.Headers;

--- a/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/producer/LiKafkaProducerConfig.java
+++ b/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/producer/LiKafkaProducerConfig.java
@@ -51,6 +51,7 @@ public class LiKafkaProducerConfig extends AbstractConfig {
   public static final String MAX_REQUEST_SIZE_CONFIG = ProducerConfig.MAX_REQUEST_SIZE_CONFIG;
   public static final String LARGE_MESSAGE_SEGMENT_WRAPPING_REQUIRED_CONFIG =
       "li.large.message.segment.wrapping.required";
+  public static final String ENABLE_RECORD_HEADER_CONFIG = "li.record.header.enable";
 
   public static final String LARGE_MESSAGE_ENABLED_DOC = "Configure the producer to support large messages or not. " +
       "If large message is enabled, the producer will split the messages whose size is greater than " +
@@ -98,6 +99,8 @@ public class LiKafkaProducerConfig extends AbstractConfig {
       "and thus not split into multiple messages. This configuration does not have any effect if large message is " +
       "not enabled.";
 
+  public static final String ENABLE_RECORD_HEADER_DOC = "If true, we will use record header based large message support and stop using segmentSerializer.";
+
   static {
     // TODO: Add a default metadata service client class.
     CONFIG = new ConfigDef()
@@ -120,7 +123,8 @@ public class LiKafkaProducerConfig extends AbstractConfig {
         .define(LARGE_MESSAGE_SEGMENT_WRAPPING_REQUIRED_CONFIG, Type.BOOLEAN, "false", Importance.MEDIUM,
             LARGE_MESSAGE_SEGMENT_WRAPPING_REQUIRED_DOC)
         .define(METADATA_SERVICE_REQUEST_TIMEOUT_MS_CONFIG, Type.INT, Integer.MAX_VALUE, Importance.MEDIUM,
-            METADATA_SERVICE_REQUEST_TIMEOUT_MS_DOC);
+            METADATA_SERVICE_REQUEST_TIMEOUT_MS_DOC)
+        .define(ENABLE_RECORD_HEADER_CONFIG, Type.BOOLEAN, "false", Importance.MEDIUM, ENABLE_RECORD_HEADER_DOC);
     ;
   }
 

--- a/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/producer/LiKafkaProducerConfig.java
+++ b/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/producer/LiKafkaProducerConfig.java
@@ -99,7 +99,8 @@ public class LiKafkaProducerConfig extends AbstractConfig {
       "and thus not split into multiple messages. This configuration does not have any effect if large message is " +
       "not enabled.";
 
-  public static final String ENABLE_RECORD_HEADER_DOC = "If true, we will utilize record headers for large message support and other serialization(e.g. encryption or compression) and stop using segmentSerializer.";
+  public static final String ENABLE_RECORD_HEADER_DOC = "If true, we will utilize record headers for large message support "
+      + "and other serialization(e.g. encryption or compression) and stop using segmentSerializer.";
 
   static {
     // TODO: Add a default metadata service client class.

--- a/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/producer/LiKafkaProducerConfig.java
+++ b/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/producer/LiKafkaProducerConfig.java
@@ -99,7 +99,7 @@ public class LiKafkaProducerConfig extends AbstractConfig {
       "and thus not split into multiple messages. This configuration does not have any effect if large message is " +
       "not enabled.";
 
-  public static final String ENABLE_RECORD_HEADER_DOC = "If true, we will use record header based large message support and stop using segmentSerializer.";
+  public static final String ENABLE_RECORD_HEADER_DOC = "If true, we will utilize record headers for large message support and other serialization(e.g. encryption or compression) and stop using segmentSerializer.";
 
   static {
     // TODO: Add a default metadata service client class.

--- a/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/producer/LiKafkaProducerImpl.java
+++ b/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/producer/LiKafkaProducerImpl.java
@@ -304,6 +304,12 @@ public class LiKafkaProducerImpl<K, V> implements LiKafkaProducer<K, V> {
         }
       }
 
+      // TODO: discuss with navina if adding enableRecordHeader in header to pass parameter is a good choice. It may be a little strange to control if using record headers by testing if the record header has such a field.
+      if (headers.lastHeader(Constants.SHOULD_USE_HEADER) == null) {
+        headers.add(Constants.SHOULD_USE_HEADER, PrimitiveEncoderDecoder.encodeBoolean(_enableRecordHeader));
+      }
+
+
       if (LOG.isTraceEnabled()) {
         LOG.trace("Sending event: [{}, {}] with key {} to kafka topic {}",
             messageId.toString().replaceAll("-", ""),
@@ -346,8 +352,7 @@ public class LiKafkaProducerImpl<K, V> implements LiKafkaProducer<K, V> {
             partition = invokeCustomPartitioner(topic, key, serializedKey, value, serializedValue);
           }
 
-          // TODO: discuss with navina if adding enableRecordHeader in header to pass parameter is a good choice
-          headers.add(Constants.SHOULD_USE_HEADER, PrimitiveEncoderDecoder.encodeBoolean(_enableRecordHeader));
+
           // Split the payload into large message segments (they will all have the same key and same partition)
           List<ProducerRecord<byte[], byte[]>> segmentRecords =
               _messageSplitter.split(topic, partition, timestamp, messageId, serializedKey, serializedValue, headers);
@@ -368,8 +373,6 @@ public class LiKafkaProducerImpl<K, V> implements LiKafkaProducer<K, V> {
           if (partition == null && _partitioner != null) {
             partition = invokeCustomPartitioner(topic, key, serializedKey, value, serializedValue);
           }
-          // TODO: discuss with navina if adding enableRecordHeader in header to pass parameter is a good choice
-          headers.add(Constants.SHOULD_USE_HEADER, PrimitiveEncoderDecoder.encodeBoolean(_enableRecordHeader));
 
           // Wrap the paylod with a large message segment, even if the payload is not big enough to split
           List<ProducerRecord<byte[], byte[]>> wrappedRecord =

--- a/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/producer/LiKafkaProducerImpl.java
+++ b/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/producer/LiKafkaProducerImpl.java
@@ -304,9 +304,15 @@ public class LiKafkaProducerImpl<K, V> implements LiKafkaProducer<K, V> {
         }
       }
 
-      // TODO: discuss with navina if adding enableRecordHeader in header to pass parameter is a good choice. It may be a little strange to control if using record headers by testing if the record header has such a field.
-      if (headers.lastHeader(Constants.SHOULD_USE_HEADER) == null) {
-        headers.add(Constants.SHOULD_USE_HEADER, PrimitiveEncoderDecoder.encodeBoolean(_enableRecordHeader));
+      // TODO: discuss with navina if adding enableRecordHeader in header to pass parameter is a good choice.
+      // It may be a little strange to control if using record headers by testing if the record header has such a field.
+      if (_enableRecordHeader) {
+        if (headers == null) {
+          headers = new RecordHeaders();
+        }
+        if (headers.lastHeader(Constants.SHOULD_USE_HEADER) == null) {
+          headers.add(Constants.SHOULD_USE_HEADER, PrimitiveEncoderDecoder.encodeBoolean(true));
+        }
       }
 
 

--- a/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/producer/LiKafkaProducerImpl.java
+++ b/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/producer/LiKafkaProducerImpl.java
@@ -251,7 +251,7 @@ public class LiKafkaProducerImpl<K, V> implements LiKafkaProducer<K, V> {
           : configs.getConfiguredInstance(LiKafkaProducerConfig.SEGMENT_SERIALIZER_CLASS_CONFIG, Serializer.class);
       segmentSerializer.configure(configs.originals(), false);
       _uuidFactory = configs.getConfiguredInstance(LiKafkaProducerConfig.UUID_FACTORY_CLASS_CONFIG, UUIDFactory.class);
-      _messageSplitter = new MessageSplitterImpl(_maxMessageSegmentSize, segmentSerializer, _uuidFactory);
+      _messageSplitter = new MessageSplitterImpl(_maxMessageSegmentSize, segmentSerializer, _uuidFactory, _enableRecordHeader);
       _largeMessageSegmentWrappingRequired =
           configs.getBoolean(LiKafkaProducerConfig.LARGE_MESSAGE_SEGMENT_WRAPPING_REQUIRED_CONFIG);
 
@@ -303,18 +303,6 @@ public class LiKafkaProducerImpl<K, V> implements LiKafkaProducer<K, V> {
           headers.add(Constants.TIMESTAMP_HEADER, PrimitiveEncoderDecoder.encodeLong(timestamp));
         }
       }
-
-      // TODO: discuss with navina if adding enableRecordHeader in header to pass parameter is a good choice.
-      // It may be a little strange to control if using record headers by testing if the record header has such a field.
-      if (_enableRecordHeader) {
-        if (headers == null) {
-          headers = new RecordHeaders();
-        }
-        if (headers.lastHeader(Constants.SHOULD_USE_HEADER) == null) {
-          headers.add(Constants.SHOULD_USE_HEADER, PrimitiveEncoderDecoder.encodeBoolean(true));
-        }
-      }
-
 
       if (LOG.isTraceEnabled()) {
         LOG.trace("Sending event: [{}, {}] with key {} to kafka topic {}",

--- a/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/utils/Constants.java
+++ b/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/utils/Constants.java
@@ -9,6 +9,7 @@ public class Constants {
   public static final String TIMESTAMP_HEADER = "_t";
   public static final String LARGE_MESSAGE_HEADER = "_lm";
   public static final String SAFE_OFFSET_HEADER = "_so";
+  public static final String SHOULD_USE_HEADER = "_sh";
 
   /**
    * Avoid instantiating the constants class

--- a/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/utils/Constants.java
+++ b/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/utils/Constants.java
@@ -9,7 +9,6 @@ public class Constants {
   public static final String TIMESTAMP_HEADER = "_t";
   public static final String LARGE_MESSAGE_HEADER = "_lm";
   public static final String SAFE_OFFSET_HEADER = "_so";
-  public static final String SHOULD_USE_HEADER = "_sh";
 
   /**
    * Avoid instantiating the constants class

--- a/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/utils/PrimitiveEncoderDecoder.java
+++ b/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/utils/PrimitiveEncoderDecoder.java
@@ -11,6 +11,7 @@ public class PrimitiveEncoderDecoder {
   // The number of bytes for a long variable
   public static final int LONG_SIZE = Long.SIZE / Byte.SIZE;
   public static final int INT_SIZE = Integer.SIZE / Byte.SIZE;
+  public static final int BOOLEAN_SIZE = 1;
 
   /**
    * Avoid instantiating PrimitiveEncoderDecoder class
@@ -95,22 +96,39 @@ public class PrimitiveEncoderDecoder {
     return data;
   }
 
-  public static int decodeInt(byte[] input, int pos) {
-    if (input == null) {
-      throw new IllegalArgumentException("bytes cannot be null");
+
+  /**
+   * Encodes a boolean value into a {@link PrimitiveEncoderDecoder#BOOLEAN_SIZE} byte array
+   * @param value value to be encoded
+   * @param output output where encoded data will be stored
+   * @param pos position in output where value will be encoded starting from
+   */
+  public static void encodeBoolean(boolean value, byte[] output, int pos) {
+    if (output == null) {
+      throw new IllegalArgumentException("The input result cannot be null");
     }
 
     if (pos < 0) {
       throw new IllegalArgumentException("position cannot be less than zero");
     }
 
-    if (input.length < pos + INT_SIZE) {
+    if (output.length < pos + BOOLEAN_SIZE) {
       throw new IllegalArgumentException(
-          String.format("Not adequate bytes available in the input array(array length = %d, pos = %d)", input.length, pos)
+          String.format("Not adequate bytes available to encode the boolean value(array length = %d, pos = %d", output.length, pos)
       );
     }
+    output[pos] = (byte) (value ? 1 : 0);
+  }
 
-    return input[pos] << 24 | (input[pos + 1] & 0xFF) << 16 | (input[pos + 2] & 0xFF) << 8 | (input[pos + 3] & 0xFF);
+  /**
+   * Encodes a boolean value int a newly created byte[] and returns it
+   * @param value value to be encoded
+   * @return encoded value
+   */
+  public static byte[] encodeBoolean(boolean value) {
+    byte[] data = new byte[BOOLEAN_SIZE];
+    encodeBoolean(value, data, 0);
+    return data;
   }
 
   /**
@@ -120,19 +138,7 @@ public class PrimitiveEncoderDecoder {
    * @return a decoded long
    */
   public static long decodeLong(byte[] input, int pos) {
-    if (input == null) {
-      throw new IllegalArgumentException("bytes cannot be null");
-    }
-
-    if (pos < 0) {
-      throw new IllegalArgumentException("position cannot be less than zero");
-    }
-
-    if (input.length < pos + LONG_SIZE) {
-      throw new IllegalArgumentException(
-          String.format("Not adequate bytes available in the input array(array length = %d, pos = %d)", input.length, pos)
-      );
-    }
+    sanityCheck(input, pos, LONG_SIZE);
 
     return (input[pos] & 0xFFL) << 56
         | (input[pos + 1] & 0xFFL) << 48
@@ -142,5 +148,45 @@ public class PrimitiveEncoderDecoder {
         | (input[pos + 5] & 0xFFL) << 16
         | (input[pos + 6] & 0xFFL) << 8
         | (input[pos + 7] & 0xFFL);
+  }
+
+
+  /**
+   * Decodes {@link PrimitiveEncoderDecoder#INT_SIZE} bytes from offset in the input byte array
+   * @param input where to read encoded form from
+   * @param pos position in input to start reading from
+   * @return a decoded int
+   */
+  public static int decodeInt(byte[] input, int pos) {
+    sanityCheck(input, pos, INT_SIZE);
+
+    return input[pos] << 24 | (input[pos + 1] & 0xFF) << 16 | (input[pos + 2] & 0xFF) << 8 | (input[pos + 3] & 0xFF);
+  }
+
+  /**
+   * Decodes {@link PrimitiveEncoderDecoder#BOOLEAN_SIZE} bytes from offset in the input byte array
+   * @param input where to read encoded form from
+   * @param pos position in input to start reading from
+   * @return a decoded boolean
+   */
+  public static boolean decodeBoolean(byte[] input, int pos) {
+    sanityCheck(input, pos, BOOLEAN_SIZE);
+    return input[pos] == 1;
+  }
+
+  private static void sanityCheck(byte[] input, int pos, int dataSize) {
+    if (input == null) {
+      throw new IllegalArgumentException("bytes cannot be null");
+    }
+
+    if (pos < 0) {
+      throw new IllegalArgumentException("position cannot be less than zero");
+    }
+
+    if (input.length < pos + dataSize) {
+      throw new IllegalArgumentException(
+          String.format("Not adequate bytes available in the input array(array length = %d, pos = %d)", input.length, pos)
+      );
+    }
   }
 }

--- a/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/utils/PrimitiveEncoderDecoder.java
+++ b/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/utils/PrimitiveEncoderDecoder.java
@@ -11,7 +11,6 @@ public class PrimitiveEncoderDecoder {
   // The number of bytes for a long variable
   public static final int LONG_SIZE = Long.SIZE / Byte.SIZE;
   public static final int INT_SIZE = Integer.SIZE / Byte.SIZE;
-  public static final int BOOLEAN_SIZE = 1;
 
   /**
    * Avoid instantiating PrimitiveEncoderDecoder class
@@ -96,29 +95,6 @@ public class PrimitiveEncoderDecoder {
     return data;
   }
 
-
-  /**
-   * Encodes a boolean value into a {@link PrimitiveEncoderDecoder#BOOLEAN_SIZE} byte array
-   * @param value value to be encoded
-   * @param output output where encoded data will be stored
-   * @param pos position in output where value will be encoded starting from
-   */
-  public static void encodeBoolean(boolean value, byte[] output, int pos) {
-    if (output == null) {
-      throw new IllegalArgumentException("The input result cannot be null");
-    }
-
-    if (pos < 0) {
-      throw new IllegalArgumentException("position cannot be less than zero");
-    }
-
-    if (output.length < pos + BOOLEAN_SIZE) {
-      throw new IllegalArgumentException(
-          String.format("Not adequate bytes available to encode the boolean value(array length = %d, pos = %d", output.length, pos)
-      );
-    }
-    output[pos] = (byte) (value ? 1 : 0);
-  }
 
   /**
    * Decodes {@link PrimitiveEncoderDecoder#LONG_SIZE} bytes from offset in the input byte array

--- a/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/utils/PrimitiveEncoderDecoder.java
+++ b/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/utils/PrimitiveEncoderDecoder.java
@@ -121,17 +121,6 @@ public class PrimitiveEncoderDecoder {
   }
 
   /**
-   * Encodes a boolean value int a newly created byte[] and returns it
-   * @param value value to be encoded
-   * @return encoded value
-   */
-  public static byte[] encodeBoolean(boolean value) {
-    byte[] data = new byte[BOOLEAN_SIZE];
-    encodeBoolean(value, data, 0);
-    return data;
-  }
-
-  /**
    * Decodes {@link PrimitiveEncoderDecoder#LONG_SIZE} bytes from offset in the input byte array
    * @param input where to read encoded form from
    * @param pos position in input to start reading from
@@ -161,17 +150,6 @@ public class PrimitiveEncoderDecoder {
     sanityCheck(input, pos, INT_SIZE);
 
     return input[pos] << 24 | (input[pos + 1] & 0xFF) << 16 | (input[pos + 2] & 0xFF) << 8 | (input[pos + 3] & 0xFF);
-  }
-
-  /**
-   * Decodes {@link PrimitiveEncoderDecoder#BOOLEAN_SIZE} bytes from offset in the input byte array
-   * @param input where to read encoded form from
-   * @param pos position in input to start reading from
-   * @return a decoded boolean
-   */
-  public static boolean decodeBoolean(byte[] input, int pos) {
-    sanityCheck(input, pos, BOOLEAN_SIZE);
-    return input[pos] == 1;
   }
 
   private static void sanityCheck(byte[] input, int pos, int dataSize) {


### PR DESCRIPTION
This PR adds `enableRecordHeader` config in producer. When it is true, producer will add a new field in the record header and skip segment serialization in MsgSplitter. The type(version) field in LMHeaderValue will be set to V3 as well, which means we will only use record header based LM support. 
By detecting the type(version) field in LMHeaderValue, consumer  can choose if it should use segment deserialization in MsgAssembler. So we do not need to add this config in consumer side.