### PR TITLE
Add new LiKafkaConsumerImpl metric - _offsetInvalidOrOutRangeCounter to estimate the potential data loss

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,7 +50,7 @@ project.ext {
     }
   }
   liKafkaVersion = "2.0.0.27"
-  marioVersion = "0.0.34"
+  marioVersion = "0.0.56"
 }
 
 subprojects {
@@ -62,6 +62,7 @@ subprojects {
     plugins.apply('checkstyle')
 
     repositories {
+      mavenLocal()
       jcenter()
       maven {
         url "https://dl.bintray.com/linkedin/maven"

--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,7 @@ project.ext {
       url "https://github.com/linkedin/li-apache-kafka-clients"
     }
   }
-  liKafkaVersion = "2.0.0.27"
+  liKafkaVersion = "2.0.0.28"
   marioVersion = "0.0.56"
 }
 

--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -13,7 +13,7 @@ dependencies {
     exclude group: 'org.slf4j', module:'slf4j-log4j12'
   }
   testCompile ("com.linkedin.mario:mario-vertx:${rootProject.ext.marioVersion}") {
-
+    exclude group: "com.linkedin.northguard"
   }
 //  testCompile ("com.linkedin.mario:mario-integration-tests:${rootProject.ext.marioVersion}") {
 //    exclude group: 'org.apache.kafka'

--- a/integration-tests/src/test/java/com/linkedin/kafka/clients/consumer/LiKafkaInstrumentedConsumerIntegrationTest.java
+++ b/integration-tests/src/test/java/com/linkedin/kafka/clients/consumer/LiKafkaInstrumentedConsumerIntegrationTest.java
@@ -13,6 +13,7 @@ import com.linkedin.mario.common.models.v1.ClientConfigRules;
 import com.linkedin.mario.common.models.v1.ClientPredicates;
 import com.linkedin.mario.common.models.v1.KafkaClusterDescriptor;
 import com.linkedin.mario.server.EmbeddableMario;
+import com.linkedin.mario.server.config.MarioConfiguration;
 import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
 import java.time.Duration;
@@ -76,7 +77,9 @@ public class LiKafkaInstrumentedConsumerIntegrationTest extends AbstractKafkaCli
     producer.flush();
     producer.close(1, TimeUnit.MINUTES);
 
-    EmbeddableMario mario = new EmbeddableMario(null);
+    MarioConfiguration marioConfiguration = MarioConfiguration.embeddableInMem();
+    marioConfiguration.setEnableNgSupport(false);
+    EmbeddableMario mario = new EmbeddableMario(marioConfiguration);
     Random random = new Random();
     int beforeBatchSize = 1 + random.nextInt(20); //[1, 20]
 
@@ -90,7 +93,8 @@ public class LiKafkaInstrumentedConsumerIntegrationTest extends AbstractKafkaCli
         zkConnect(),
         bootstrapServers(),
         "test",
-        0L
+        0L,
+        false
     );
     mario.addKafkaCluster(kafkaClusterDescriptor).get();
 

--- a/integration-tests/src/test/java/com/linkedin/kafka/clients/producer/LiKafkaInstrumentedProducerIntegrationTest.java
+++ b/integration-tests/src/test/java/com/linkedin/kafka/clients/producer/LiKafkaInstrumentedProducerIntegrationTest.java
@@ -14,6 +14,7 @@ import com.linkedin.mario.common.models.v1.ClientConfigRules;
 import com.linkedin.mario.common.models.v1.ClientPredicates;
 import com.linkedin.mario.common.models.v1.KafkaClusterDescriptor;
 import com.linkedin.mario.server.EmbeddableMario;
+import com.linkedin.mario.server.config.MarioConfiguration;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.Properties;
@@ -54,7 +55,9 @@ public class LiKafkaInstrumentedProducerIntegrationTest extends AbstractKafkaCli
   public void testProducerLiveConfigReload() throws Exception {
     String topic = "testProducerLiveConfigReload";
     createTopic(topic, 1);
-    EmbeddableMario mario = new EmbeddableMario(null);
+    MarioConfiguration marioConfiguration = MarioConfiguration.embeddableInMem();
+    marioConfiguration.setEnableNgSupport(false);
+    EmbeddableMario mario = new EmbeddableMario(marioConfiguration);
     Random random = new Random();
 
     // register kafka cluster to EmbeddableMario
@@ -67,7 +70,8 @@ public class LiKafkaInstrumentedProducerIntegrationTest extends AbstractKafkaCli
         zkConnect(),
         bootstrapServers(),
         "test",
-        0L
+        0L,
+        false
     );
     mario.addKafkaCluster(kafkaClusterDescriptor).get();
 

--- a/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/common/InstrumentedClientLoggingHandler.java
+++ b/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/common/InstrumentedClientLoggingHandler.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2020 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License").  See License in the project root for license information.
+ */
+
+package com.linkedin.kafka.clients.common;
+
+import com.linkedin.kafka.clients.utils.LiKafkaClientsUtils;
+import com.linkedin.mario.client.LoggingHandler;
+import org.slf4j.Logger;
+
+
+/**
+ * logging handler for instrumented clients to log connection issues
+ * to conductor.
+ * since conductor is an optional dependency for these clients the
+ * logging performed is less verbose and emits warnings instead
+ * of errors (which is what the default conductor client would do)
+ */
+public class InstrumentedClientLoggingHandler implements LoggingHandler {
+  private final Logger logger;
+  private final String clientId;
+  private final String prefix;
+
+  public InstrumentedClientLoggingHandler(Logger logger, String clientId) {
+    if (logger == null) {
+      throw new IllegalArgumentException("must provide logger");
+    }
+    this.logger = logger;
+    this.clientId = clientId;
+    this.prefix = this.clientId == null ? "" : ("client " + clientId + " ");
+  }
+
+  @Override
+  public void logConnectionFailure(
+      String lastAttemptedWebsocketUrl,
+      Throwable issue,
+      long failureTime,
+      int numConsecutiveFailures,
+      long delayToNextAttempt) {
+    if (numConsecutiveFailures == 1) {
+      Throwable root = LiKafkaClientsUtils.getRootCause(issue); //could be null
+      String rootDesc = root == null ? "" : (" (" + root.getMessage() + ")");
+      //only log on 1st failure, log a warning, and dont display full stack trace
+      if (lastAttemptedWebsocketUrl == null || lastAttemptedWebsocketUrl.isEmpty()) {
+        logger.warn("{}unable to locate conductor{}. will keep retrying in the background", prefix, rootDesc);
+      } else {
+        logger.warn("{}unable to open websocket to conductor at {}{}. will keep retrying in the background",
+            prefix, lastAttemptedWebsocketUrl, rootDesc);
+      }
+    }
+  }
+}

--- a/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/consumer/LiKafkaConsumerImpl.java
+++ b/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/consumer/LiKafkaConsumerImpl.java
@@ -350,10 +350,6 @@ public class LiKafkaConsumerImpl<K, V> implements LiKafkaConsumer<K, V> {
         }
       } catch (OffsetOutOfRangeException | NoOffsetForPartitionException oe) {
         handleInvalidOffsetException(oe);
-<<<<<<< HEAD
-=======
-        _offsetInvalidOrOutRangeCount.getAndIncrement();
->>>>>>> Add counter metric for offset out of range & invalid exceptions in LiKafkaConsumerImpl
         // force throw exception if exception.on.invalid.offset.reset is set to true
         if (_throwExceptionOnInvalidOffsets) {
           throw oe;

--- a/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/consumer/LiKafkaConsumerImpl.java
+++ b/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/consumer/LiKafkaConsumerImpl.java
@@ -155,7 +155,7 @@ public class LiKafkaConsumerImpl<K, V> implements LiKafkaConsumer<K, V> {
     };
 
     MetricName offsetOutOfRangeCounterName = new MetricName(
-        "consumer-num-invalid-offset-exceptions",
+        "consumer-liclosest-data-loss-estimation",
         "lnkd",
         "counter of how many times the consumer reached OffsetOutOfRangeException or NoOffsetForPartitionException"
             + "with liclosest reset strategy (case 2 and 3b) for potential data loss estimation.",

--- a/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/consumer/LiKafkaConsumerImpl.java
+++ b/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/consumer/LiKafkaConsumerImpl.java
@@ -719,10 +719,12 @@ public class LiKafkaConsumerImpl<K, V> implements LiKafkaConsumer<K, V> {
 
       if (!seekBeginningPartitions.isEmpty()) {
         LOG.info("Offsets are out of range for partitions {}. Seeking to the beginning offsets returned", seekBeginningPartitions);
+        _offsetInvalidOrOutRangeCount.getAndIncrement();
         seekBeginningPartitions.forEach(this::seekAndClear);
       }
       if (!seekEndPartitions.isEmpty()) {
         LOG.info("Offsets are out of range for partitions {}. Seeking to the end offsets returned", seekEndPartitions);
+        _offsetInvalidOrOutRangeCount.getAndIncrement();
         seekEndPartitions.forEach(this::seekAndClear);
       }
       if (!seekFetchedOffsetPartitions.isEmpty()) {

--- a/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/consumer/LiKafkaConsumerImpl.java
+++ b/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/consumer/LiKafkaConsumerImpl.java
@@ -350,6 +350,10 @@ public class LiKafkaConsumerImpl<K, V> implements LiKafkaConsumer<K, V> {
         }
       } catch (OffsetOutOfRangeException | NoOffsetForPartitionException oe) {
         handleInvalidOffsetException(oe);
+<<<<<<< HEAD
+=======
+        _offsetInvalidOrOutRangeCount.getAndIncrement();
+>>>>>>> Add counter metric for offset out of range & invalid exceptions in LiKafkaConsumerImpl
         // force throw exception if exception.on.invalid.offset.reset is set to true
         if (_throwExceptionOnInvalidOffsets) {
           throw oe;
@@ -719,10 +723,12 @@ public class LiKafkaConsumerImpl<K, V> implements LiKafkaConsumer<K, V> {
 
       if (!seekBeginningPartitions.isEmpty()) {
         LOG.info("Offsets are out of range for partitions {}. Seeking to the beginning offsets returned", seekBeginningPartitions);
+        _offsetInvalidOrOutRangeCount.getAndIncrement();
         seekBeginningPartitions.forEach(this::seekAndClear);
       }
       if (!seekEndPartitions.isEmpty()) {
         LOG.info("Offsets are out of range for partitions {}. Seeking to the end offsets returned", seekEndPartitions);
+        _offsetInvalidOrOutRangeCount.getAndIncrement();
         seekEndPartitions.forEach(this::seekAndClear);
       }
       if (!seekFetchedOffsetPartitions.isEmpty()) {

--- a/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/consumer/LiKafkaConsumerImpl.java
+++ b/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/consumer/LiKafkaConsumerImpl.java
@@ -719,12 +719,10 @@ public class LiKafkaConsumerImpl<K, V> implements LiKafkaConsumer<K, V> {
 
       if (!seekBeginningPartitions.isEmpty()) {
         LOG.info("Offsets are out of range for partitions {}. Seeking to the beginning offsets returned", seekBeginningPartitions);
-        _offsetInvalidOrOutRangeCount.getAndIncrement();
         seekBeginningPartitions.forEach(this::seekAndClear);
       }
       if (!seekEndPartitions.isEmpty()) {
         LOG.info("Offsets are out of range for partitions {}. Seeking to the end offsets returned", seekEndPartitions);
-        _offsetInvalidOrOutRangeCount.getAndIncrement();
         seekEndPartitions.forEach(this::seekAndClear);
       }
       if (!seekFetchedOffsetPartitions.isEmpty()) {

--- a/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/consumer/LiKafkaConsumerImpl.java
+++ b/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/consumer/LiKafkaConsumerImpl.java
@@ -155,9 +155,9 @@ public class LiKafkaConsumerImpl<K, V> implements LiKafkaConsumer<K, V> {
     };
 
     MetricName offsetOutOfRangeCounterName = new MetricName(
-        "consumer-offset-out-of-range-counter",
+        "consumer-num-invalid-offset-exceptions",
         "lnkd",
-        "counter of how many times the consumer reached OffsetOutOfRange or Invalid Offset exceptions.",
+        "counter of how many times the consumer reached OffsetOutOfRangeException or NoOffsetForPartitionException.",
         Collections.singletonMap("client-id", _clientId)
     );
     Metric offsetOutOfRangeCounter = new Metric() {

--- a/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/consumer/LiKafkaConsumerImpl.java
+++ b/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/consumer/LiKafkaConsumerImpl.java
@@ -717,12 +717,10 @@ public class LiKafkaConsumerImpl<K, V> implements LiKafkaConsumer<K, V> {
 
       if (!seekBeginningPartitions.isEmpty()) {
         LOG.info("Offsets are out of range for partitions {}. Seeking to the beginning offsets returned", seekBeginningPartitions);
-        _offsetInvalidOrOutRangeCount.getAndIncrement();
         seekBeginningPartitions.forEach(this::seekAndClear);
       }
       if (!seekEndPartitions.isEmpty()) {
         LOG.info("Offsets are out of range for partitions {}. Seeking to the end offsets returned", seekEndPartitions);
-        _offsetInvalidOrOutRangeCount.getAndIncrement();
         seekEndPartitions.forEach(this::seekAndClear);
       }
       if (!seekFetchedOffsetPartitions.isEmpty()) {

--- a/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/consumer/LiKafkaConsumerImpl.java
+++ b/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/consumer/LiKafkaConsumerImpl.java
@@ -157,7 +157,8 @@ public class LiKafkaConsumerImpl<K, V> implements LiKafkaConsumer<K, V> {
     MetricName offsetOutOfRangeCounterName = new MetricName(
         "consumer-num-invalid-offset-exceptions",
         "lnkd",
-        "counter of how many times the consumer reached OffsetOutOfRangeException or NoOffsetForPartitionException.",
+        "counter of how many times the consumer reached OffsetOutOfRangeException or NoOffsetForPartitionException"
+            + "with liclosest reset strategy (case 2 and 3b) for potential data loss estimation.",
         Collections.singletonMap("client-id", _clientId)
     );
     Metric offsetOutOfRangeCounter = new Metric() {

--- a/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/consumer/LiKafkaConsumerImpl.java
+++ b/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/consumer/LiKafkaConsumerImpl.java
@@ -349,7 +349,6 @@ public class LiKafkaConsumerImpl<K, V> implements LiKafkaConsumer<K, V> {
         }
       } catch (OffsetOutOfRangeException | NoOffsetForPartitionException oe) {
         handleInvalidOffsetException(oe);
-        _offsetInvalidOrOutRangeCount.getAndIncrement();
         // force throw exception if exception.on.invalid.offset.reset is set to true
         if (_throwExceptionOnInvalidOffsets) {
           throw oe;
@@ -694,6 +693,7 @@ public class LiKafkaConsumerImpl<K, V> implements LiKafkaConsumer<K, V> {
         if (beginningOffset != -1L && endOffset != -1L) {
           if (beginningOffset > fetchedOffset) {  // Case 2
             seekBeginningPartitions.put(tp, beginningOffset);
+            _offsetInvalidOrOutRangeCount.getAndIncrement();
             return;
           }
           if (endOffset < fetchedOffset) {  // Case 3a
@@ -702,6 +702,7 @@ public class LiKafkaConsumerImpl<K, V> implements LiKafkaConsumer<K, V> {
           } else {  // Case 3b: endOffset >= fetchedOffset
             LOG.debug("Closest offset computed for topic partition {} is the fetched offset {}. ", tp, fetchedOffset);
             seekFetchedOffsetPartitions.put(tp, fetchedOffset);
+            _offsetInvalidOrOutRangeCount.getAndIncrement();
           }
         } else {
           // can't handle reset if the either bound values are not known

--- a/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/largemessage/MessageSplitterImpl.java
+++ b/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/largemessage/MessageSplitterImpl.java
@@ -117,7 +117,7 @@ public class MessageSplitterImpl implements MessageSplitter {
       byte[] segmentValue;
       byte largeMessageHeaderValueVersion;
       if (_enableRecordHeader) {
-        segmentValue = payload.array();
+        segmentValue = segment.payloadArray();
         largeMessageHeaderValueVersion = LargeMessageHeaderValue.V3;
       } else {
         // NOTE: Even though we are passing topic here to serialize, the segment itself should be topic independent.

--- a/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/utils/LiKafkaClientsUtils.java
+++ b/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/utils/LiKafkaClientsUtils.java
@@ -254,4 +254,17 @@ public class LiKafkaClientsUtils {
         ? LargeMessageHeaderValue.fromBytes(specialHeaders.get(Constants.LARGE_MESSAGE_HEADER))
         : null;
   }
+
+  public static Throwable getRootCause(Throwable t) {
+    if (t == null) {
+      return null;
+    }
+    Throwable root = t;
+    Throwable cause = root.getCause();
+    while (cause != null && cause != t) {
+      root = cause;
+      cause = root.getCause();
+    }
+    return root;
+  }
 }


### PR DESCRIPTION
Added new metric( _offsetInvalidOrOutRangeCounter) into LiKafkaConsumerImpl to count number of OffsetOutOfRange exceptions under following cases with liclosest reset strategy.

**1. fetchedOffset <  Log Start Offset (LSO)
2. fetchedOffset <= Log End Offset (LEO)**

This metric can be used as indicator to estimate the potential data loss upon the LiKafkaConsumer client reseting the offset to "liclosest"
