### PR TITLE
add test and fix a bug of using  payload.array()

### DIFF
--- a/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/largemessage/MessageSplitterImpl.java
+++ b/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/largemessage/MessageSplitterImpl.java
@@ -117,7 +117,7 @@ public class MessageSplitterImpl implements MessageSplitter {
       byte[] segmentValue;
       byte largeMessageHeaderValueVersion;
       if (_enableRecordHeader) {
-        segmentValue = payload.array();
+        segmentValue = segment.payloadArray();
         largeMessageHeaderValueVersion = LargeMessageHeaderValue.V3;
       } else {
         // NOTE: Even though we are passing topic here to serialize, the segment itself should be topic independent.


### PR DESCRIPTION
The previous (pr)[https://github.com/linkedin/li-apache-kafka-clients/pull/184] introduce a bug of   wrongly using payload.array() instead of using segment.payloadArray().
This pr is to fix that problem and add a new integration test for that config