### PR TITLE
Fix race condition in LiKafkaInstrumentedProducerImpl

### DIFF
--- a/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/producer/LiKafkaInstrumentedProducerImpl.java
+++ b/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/producer/LiKafkaInstrumentedProducerImpl.java
@@ -461,11 +461,11 @@ public class LiKafkaInstrumentedProducerImpl<K, V> implements DelegatingProducer
     }
 
     // release read lock held by current thread if any
-    // BMM has use cases of closing the producer in send callback if send fails, we need to ensure
+    // There are use cases of closing the producer in send callback if send fails, we need to ensure
     // the same ordering of acquiring/releasing locks, in this case:
     // 1. send will get the Read lock
     // 2. close will first release all Read locks; then grab the Write lock
-    int holds = delegateLock.getReadHoldCount();
+    final int holds = delegateLock.getReadHoldCount();
     ReentrantReadWriteLock.ReadLock readLock = delegateLock.readLock();
     ReentrantReadWriteLock.WriteLock writeLock = delegateLock.writeLock();
     if (holds > 0) { //do we own a read lock ?

--- a/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/producer/LiKafkaInstrumentedProducerImpl.java
+++ b/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/producer/LiKafkaInstrumentedProducerImpl.java
@@ -57,7 +57,6 @@ public class LiKafkaInstrumentedProducerImpl<K, V> implements DelegatingProducer
 
   private final long initialConnectionTimeoutMs;
   private final ReentrantReadWriteLock delegateLock = new ReentrantReadWriteLock();
-  private final Object closeLock = new Object();
   private final Properties baseConfig;
   private final Map<String, String> libraryVersions;
   private final ProducerFactory<K, V> producerFactory;
@@ -460,36 +459,39 @@ public class LiKafkaInstrumentedProducerImpl<K, V> implements DelegatingProducer
     if (isClosed()) {
       return false;
     }
-    synchronized (closeLock) {
-      if (isClosed()) {
-        return false; //someone beat us to it
+
+    // release read lock held by current thread if any
+    // BMM has use cases of closing the producer in send callback if send fails, we need to ensure
+    // the same ordering of acquiring/releasing locks, in this case:
+    // 1. send will get the Read lock
+    // 2. close will first release all Read locks; then grab the Write lock
+    int holds = delegateLock.getReadHoldCount();
+    ReentrantReadWriteLock.ReadLock readLock = delegateLock.readLock();
+    ReentrantReadWriteLock.WriteLock writeLock = delegateLock.writeLock();
+    if (holds > 0) { //do we own a read lock ?
+      for (int i = 0; i < holds; i++) {
+        readLock.unlock();
       }
-      int holds = delegateLock.getReadHoldCount(); //this is for our thread
-      ReentrantReadWriteLock.ReadLock readLock = delegateLock.readLock();
-      ReentrantReadWriteLock.WriteLock writeLock = delegateLock.writeLock();
-      if (holds > 0) { //do we own a read lock ?
-        for (int i = 0; i < holds; i++) {
-          readLock.unlock();
-        }
-        //at this point we no longer hold a read lock, but any number of other
-        //readers/writers may slip past us
-      }
+      //at this point we no longer hold a read lock, but any number of other
+      //readers/writers may slip past us. That's fine in dual close case since they will
+      //always first try to release the read locks they own.
+    }
+
+    try {
+      writeLock.lock(); //wait for a write lock
       try {
-        writeLock.lock(); //wait for a write lock
-        try {
-          if (isClosed()) {
-            return false; //some other writer may have beaten us again
-          }
-          closedAt = System.currentTimeMillis();
-          return true;
-        } finally {
-          writeLock.unlock();
+        if (isClosed()) {
+          return false; //some other writer may have beaten us again
         }
+        closedAt = System.currentTimeMillis();
+        return true;
       } finally {
-        if (holds > 0) { //restore our read lock holds (if we had any)
-          for (int i = 0; i < holds; i++) {
-            readLock.lock();
-          }
+        writeLock.unlock();
+      }
+    } finally {
+      if (holds > 0) { //restore our read lock holds (if we had any)
+        for (int i = 0; i < holds; i++) {
+          readLock.lock();
         }
       }
     }


### PR DESCRIPTION
Fix race condition in LiKafkaInstrumentedProducerImpl when two threads calling close in send callback.

Problem:
BMM has a use case of calling producer.close in send callback when send fails, with current code, there could still be race conditions given the following sequence:

Both Thread 1 and Thread 2 are calling same producer.send(tp, cbk) and fails, and tries to call producer.close in the cbk:

Thread 1: Hold closeLock, (release Read lock,) wait on Write lock
Thread 2: Hold Read lock, wait on closeLock.

Thus deadlock.

Fix:
Ensure same ordering of acquiring/releasing locks when proceedClose(), i.e. first release all Read locks held by current thread, then grab Write lock to proceed closing.