### PR TITLE
Bump kafka version to pick up fix for cluster id mismatch

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,7 @@ project.ext {
       url "https://github.com/linkedin/li-apache-kafka-clients"
     }
   }
-  liKafkaVersion = "2.0.0.28"
+  liKafkaVersion = "2.0.0.29"
   marioVersion = "0.0.56"
 }
 


### PR DESCRIPTION
Bump kafka from 2.0.0.28 to 2.0.0.29 to pick up oss fix for stale cluster metadata when removing all brokers from one cluster and add the broker(s) to another cluster.