### PR TITLE
Fix Kafka flush() contract different in vanilla client v/s li-apache-kafka-clients

### DIFF
--- a/integration-tests/src/test/java/com/linkedin/kafka/clients/producer/LiKafkaInstrumentedProducerIntegrationTest.java
+++ b/integration-tests/src/test/java/com/linkedin/kafka/clients/producer/LiKafkaInstrumentedProducerIntegrationTest.java
@@ -197,7 +197,7 @@ public class LiKafkaInstrumentedProducerIntegrationTest extends AbstractKafkaCli
   }
 
   @Test
-  public void testProducerFlush() throws Exception {
+  public void testProducerFlushAfterClose() throws Exception {
     String topic = "testCloseFromProduceCallbackOnSenderThread";
     createTopic(topic, 1);
 
@@ -222,9 +222,9 @@ public class LiKafkaInstrumentedProducerIntegrationTest extends AbstractKafkaCli
     random.nextBytes(value);
     ProducerRecord<byte[], byte[]> record = new ProducerRecord<>(topic, key, value);
 
-    producer.send(record).get();
-    producer.flush(Integer.MAX_VALUE, TimeUnit.MILLISECONDS);
+    producer.send(record);
     producer.close(Duration.ofSeconds(30));
+    producer.flush(Integer.MAX_VALUE, TimeUnit.MILLISECONDS);
   }
 
   private void createTopic(String topicName, int numPartitions) throws Exception {

--- a/integration-tests/src/test/java/com/linkedin/kafka/clients/producer/LiKafkaInstrumentedProducerIntegrationTest.java
+++ b/integration-tests/src/test/java/com/linkedin/kafka/clients/producer/LiKafkaInstrumentedProducerIntegrationTest.java
@@ -229,7 +229,7 @@ public class LiKafkaInstrumentedProducerIntegrationTest extends AbstractKafkaCli
   }
 
   @Test
-  public void testProducerFlushWithBrokerKilled() throws Exception {
+  public void testProducerFlushWithTimeoutException() throws Exception {
     String topic = "testCloseFromProduceCallbackOnSenderThread";
     createTopic(topic, 1);
 

--- a/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/producer/LiKafkaInstrumentedProducerImpl.java
+++ b/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/producer/LiKafkaInstrumentedProducerImpl.java
@@ -452,7 +452,7 @@ public class LiKafkaInstrumentedProducerImpl<K, V> implements DelegatingProducer
         delegate.close(timeout.toMillis(), TimeUnit.MILLISECONDS);
       }
     } finally {
-      this.delegate = null;
+//      this.delegate = null;
       closeMdsClient();
     }
   }

--- a/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/producer/LiKafkaInstrumentedProducerImpl.java
+++ b/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/producer/LiKafkaInstrumentedProducerImpl.java
@@ -363,9 +363,9 @@ public class LiKafkaInstrumentedProducerImpl<K, V> implements DelegatingProducer
           throw new IllegalStateException("Failed to invoke the bounded flush method", e1);
         } catch (InvocationTargetException e2) {
             if (e2.getCause() instanceof RuntimeException) {
-              throw new RuntimeException("Failed to flush due to RuntimeException", e2.getCause());
+              throw (RuntimeException) e2.getCause();
             } else {
-              throw new IllegalStateException("Failed to invoke the bounded flush method", e2.getCause());
+              throw new IllegalStateException("Failed to invoke the bounded flush method", e2);
             }
           }
       } else {

--- a/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/producer/LiKafkaInstrumentedProducerImpl.java
+++ b/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/producer/LiKafkaInstrumentedProducerImpl.java
@@ -359,15 +359,13 @@ public class LiKafkaInstrumentedProducerImpl<K, V> implements DelegatingProducer
       if (boundedFlushMethod != null) {
         try {
           boundedFlushMethod.invoke(delegate, timeout, timeUnit);
-        } catch (IllegalAccessException illegalAccessException) {
-          throw new IllegalStateException("Failed to invoke the bounded flush method", illegalAccessException.getCause());
-        } catch (InvocationTargetException invocationTargetException) {
-          try {
-            throw (Exception) invocationTargetException.getCause();
-          } catch (Exception exception) {
-            exception.printStackTrace();
+        } catch (Exception e) {
+            if (e.getCause() instanceof RuntimeException) {
+              throw new RuntimeException("Failed to flush due to RuntimeException", e.getCause());
+            } else {
+              throw new IllegalStateException("Failed to invoke the bounded flush method", e.getCause());
+            }
           }
-        }
       } else {
         useSeparateThreadForFlush = true;
       }
@@ -452,7 +450,6 @@ public class LiKafkaInstrumentedProducerImpl<K, V> implements DelegatingProducer
         delegate.close(timeout.toMillis(), TimeUnit.MILLISECONDS);
       }
     } finally {
-//      this.delegate = null;
       closeMdsClient();
     }
   }

--- a/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/producer/LiKafkaInstrumentedProducerImpl.java
+++ b/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/producer/LiKafkaInstrumentedProducerImpl.java
@@ -337,8 +337,6 @@ public class LiKafkaInstrumentedProducerImpl<K, V> implements DelegatingProducer
 
   @Override
   public void flush() {
-    verifyOpen();
-
     delegateLock.readLock().lock();
     try {
       delegate.flush();
@@ -355,8 +353,6 @@ public class LiKafkaInstrumentedProducerImpl<K, V> implements DelegatingProducer
    * If the underlying producer doesn't support a bounded flush, it will invoke the {@link #flush()}.
    */
   public void flush(long timeout, TimeUnit timeUnit) {
-    verifyOpen();
-
     delegateLock.readLock().lock();
     try {
       boolean useSeparateThreadForFlush = false;

--- a/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/producer/LiKafkaInstrumentedProducerImpl.java
+++ b/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/producer/LiKafkaInstrumentedProducerImpl.java
@@ -359,8 +359,14 @@ public class LiKafkaInstrumentedProducerImpl<K, V> implements DelegatingProducer
       if (boundedFlushMethod != null) {
         try {
           boundedFlushMethod.invoke(delegate, timeout, timeUnit);
-        } catch (IllegalAccessException | InvocationTargetException e) {
-          throw new IllegalStateException("failed to invoke the bounded flush method", e);
+        } catch (IllegalAccessException illegalAccessException) {
+          throw new IllegalStateException("Failed to invoke the bounded flush method", illegalAccessException.getCause());
+        } catch (InvocationTargetException invocationTargetException) {
+          try {
+            throw (Exception) invocationTargetException.getCause();
+          } catch (Exception exception) {
+            exception.printStackTrace();
+          }
         }
       } else {
         useSeparateThreadForFlush = true;

--- a/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/producer/LiKafkaInstrumentedProducerImpl.java
+++ b/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/producer/LiKafkaInstrumentedProducerImpl.java
@@ -359,11 +359,13 @@ public class LiKafkaInstrumentedProducerImpl<K, V> implements DelegatingProducer
       if (boundedFlushMethod != null) {
         try {
           boundedFlushMethod.invoke(delegate, timeout, timeUnit);
-        } catch (Exception e) {
-            if (e.getCause() instanceof RuntimeException) {
-              throw new RuntimeException("Failed to flush due to RuntimeException", e.getCause());
+        } catch (IllegalAccessException e1) {
+          throw new IllegalStateException("Failed to invoke the bounded flush method", e1);
+        } catch (InvocationTargetException e2) {
+            if (e2.getCause() instanceof RuntimeException) {
+              throw new RuntimeException("Failed to flush due to RuntimeException", e2.getCause());
             } else {
-              throw new IllegalStateException("Failed to invoke the bounded flush method", e.getCause());
+              throw new IllegalStateException("Failed to invoke the bounded flush method", e2.getCause());
             }
           }
       } else {

--- a/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/producer/LiKafkaInstrumentedProducerImpl.java
+++ b/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/producer/LiKafkaInstrumentedProducerImpl.java
@@ -359,13 +359,13 @@ public class LiKafkaInstrumentedProducerImpl<K, V> implements DelegatingProducer
       if (boundedFlushMethod != null) {
         try {
           boundedFlushMethod.invoke(delegate, timeout, timeUnit);
-        } catch (IllegalAccessException e1) {
-          throw new IllegalStateException("Failed to invoke the bounded flush method", e1);
-        } catch (InvocationTargetException e2) {
-            if (e2.getCause() instanceof RuntimeException) {
-              throw (RuntimeException) e2.getCause();
+        } catch (IllegalAccessException illegalAccessException) {
+          throw new IllegalStateException("Failed to invoke the bounded flush method", illegalAccessException);
+        } catch (InvocationTargetException invocationTargetException) {
+            if (invocationTargetException.getCause() instanceof RuntimeException) {
+              throw (RuntimeException) invocationTargetException.getCause();
             } else {
-              throw new IllegalStateException("Failed to invoke the bounded flush method", e2);
+              throw new IllegalStateException("Failed to invoke the bounded flush method", invocationTargetException);
             }
           }
       } else {

--- a/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/producer/LiKafkaProducerImpl.java
+++ b/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/producer/LiKafkaProducerImpl.java
@@ -423,8 +423,14 @@ public class LiKafkaProducerImpl<K, V> implements LiKafkaProducer<K, V> {
     if (_boundedFlushMethod != null) {
       try {
         _boundedFlushMethod.invoke(_producer, timeout, timeUnit);
-      } catch (IllegalAccessException | InvocationTargetException e) {
-        throw new IllegalStateException("failed to invoke the bounded flush method", e);
+      } catch (IllegalAccessException illegalAccessException) {
+        throw new IllegalStateException("Failed to invoke the bounded flush method", illegalAccessException);
+      } catch (InvocationTargetException invocationTargetException) {
+        if (invocationTargetException.getCause() instanceof RuntimeException) {
+          throw (RuntimeException) invocationTargetException.getCause();
+        } else {
+          throw new IllegalStateException("Failed to invoke the bounded flush method", invocationTargetException);
+        }
       }
     } else {
       useSeparateThreadForFlush = true;


### PR DESCRIPTION
This request aims to fixing li-apache-kafka-clients producer flush() contract different in vanilla client.

- Removed verifyOpen() from flush() and flush(long timeout, TimeUnit timeUnit).
- Peeled InvocationTargetException and re-throw vanilla client exception.
- Added flush() integration test. 