### PR TITLE
Bypass large message processing when passthrough is enabled for consumer

### DIFF
--- a/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/consumer/LiKafkaConsumerConfig.java
+++ b/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/consumer/LiKafkaConsumerConfig.java
@@ -90,6 +90,10 @@ public class LiKafkaConsumerConfig extends AbstractConfig {
 
   private static final String AUDITOR_CLASS_DOC = "The auditor class to use for the consumer";
 
+  private static final String ENABLE_SHALLOW_ITERATOR_DOC = "If true consumer will return the raw byte record to caller directly"
+      + " without performing large message processing. Shallow iterator means: Shallow iterate message batches in the consumer, "
+      + " returning message batches (potentially compressed) instead of individual records";
+
   private static final String ENABLE_AUTO_COMMIT_DOC = "If true the consumer's offset will be periodically committed in" +
       " the background.";
 
@@ -169,6 +173,11 @@ public class LiKafkaConsumerConfig extends AbstractConfig {
                 NoOpAuditor.class.getName(),
                 Importance.LOW,
                 AUDITOR_CLASS_DOC)
+        .define(ConsumerConfig.ENABLE_SHALLOW_ITERATOR_CONFIG,
+            Type.BOOLEAN,
+            "false",
+            Importance.LOW,
+            ENABLE_SHALLOW_ITERATOR_DOC)
         .define(ENABLE_AUTO_COMMIT_CONFIG,
                 Type.BOOLEAN,
                 "true",

--- a/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/consumer/LiKafkaConsumerImpl.java
+++ b/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/consumer/LiKafkaConsumerImpl.java
@@ -76,6 +76,7 @@ public class LiKafkaConsumerImpl<K, V> implements LiKafkaConsumer<K, V> {
   private final ConsumerRecordsProcessor<K, V> _consumerRecordsProcessor;
   private final LiKafkaConsumerRebalanceListener<K, V> _consumerRebalanceListener;
   private final LiKafkaOffsetCommitCallback _offsetCommitCallback;
+  private final boolean _passthroughEnabled;
   private final boolean _autoCommitEnabled;
   private final long _autoCommitInterval;
   private final boolean _throwExceptionOnInvalidOffsets;
@@ -119,6 +120,7 @@ public class LiKafkaConsumerImpl<K, V> implements LiKafkaConsumer<K, V> {
 
     _autoCommitEnabled = configs.getBoolean(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG);
     _autoCommitInterval = configs.getInt(ConsumerConfig.AUTO_COMMIT_INTERVAL_MS_CONFIG);
+    _passthroughEnabled = configs.getBoolean(ConsumerConfig.ENABLE_SHALLOW_ITERATOR_CONFIG);
     _throwExceptionOnInvalidOffsets = configs.getBoolean(LiKafkaConsumerConfig.EXCEPTION_ON_INVALID_OFFSET_RESET_CONFIG);
     _offsetResetStrategy =
         LiOffsetResetStrategy.valueOf(configs.getString(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG).toUpperCase(Locale.ROOT));
@@ -356,19 +358,27 @@ public class LiKafkaConsumerImpl<K, V> implements LiKafkaConsumer<K, V> {
         }
       }
 
-      _lastProcessedResult = _consumerRecordsProcessor.process(rawRecords);
-      processedRecords = _lastProcessedResult.consumerRecords();
-      // Clear the internal reference.
-      _lastProcessedResult.clearRecords();
-      // Rewind offset if there are processing exceptions.
-      seekToCurrentOffsetsOnRecordProcessingExceptions();
+      /* Hack for passthrough mirroring: since Brooklin is the only user of passthrough feature and they only
+       * use raw <byte[], byte[]> consumer, there's no need to perform large message processing in this case,
+       * and should just return the consumed records directly to the caller.
+       */
+      if (_passthroughEnabled) {
+        processedRecords = (ConsumerRecords<K, V>) rawRecords;
+      } else {
+        _lastProcessedResult = _consumerRecordsProcessor.process(rawRecords);
+        processedRecords = _lastProcessedResult.consumerRecords();
+        // Clear the internal reference.
+        _lastProcessedResult.clearRecords();
+        // Rewind offset if there are processing exceptions.
+        seekToCurrentOffsetsOnRecordProcessingExceptions();
 
-      // this is an optimization
-      // if no records were processed try to throw exception in current poll()
-      if (processedRecords.isEmpty()) {
-        crpe = handleRecordProcessingException(null);
-        if (crpe != null) {
-          throw crpe;
+        // this is an optimization
+        // if no records were processed try to throw exception in current poll()
+        if (processedRecords.isEmpty()) {
+          crpe = handleRecordProcessingException(null);
+          if (crpe != null) {
+            throw crpe;
+          }
         }
       }
 


### PR DESCRIPTION
Problem: When BMM testing the passthrough feature, it turns out during ConsumerRecordsProcessor.handleConsumerRecord, we are transforming the underlying PassthroughConsumerRecord into ConsumerRecord type, thus causing some type cast issue in the caller.

Fix: When passthrough is enabled on consumer side, ideally we should bypass the large message processing part and just return the consumed record directly to the caller.

Test: added integration test to verify the return record type when enable.shallow.iterator is set to true for consumer.