### PR TITLE
Update build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,7 @@ project.ext {
       url "https://github.com/linkedin/li-apache-kafka-clients"
     }
   }
-  liKafkaVersion = "2.0.0.33"
+  liKafkaVersion = "2.0.0.35"
   marioVersion = "0.0.56"
 }
 


### PR DESCRIPTION
upgrade kafka version to 2.0.0.35 to revert the passthrough patch