### PR TITLE
Bump kafka to 2.0.0.39 to include more logging

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,7 @@ project.ext {
       url "https://github.com/linkedin/li-apache-kafka-clients"
     }
   }
-  liKafkaVersion = "2.0.0.37"
+  liKafkaVersion = "2.0.0.39"
   marioVersion = "0.0.56"
 }
 


### PR DESCRIPTION
Bump kafka version to 2.0.0.39 to include more logging when CorruptedRecordException happens.