### PR TITLE
Remove waiting for connection to conductor during instrumented client creation

### DIFF
--- a/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/consumer/LiKafkaInstrumentedConsumerImpl.java
+++ b/li-apache-kafka-clients/src/main/java/com/linkedin/kafka/clients/consumer/LiKafkaInstrumentedConsumerImpl.java
@@ -144,31 +144,6 @@ public class LiKafkaInstrumentedConsumerImpl<K, V> implements DelegatingConsumer
         this,
         loggingHandler
     );
-
-    boolean tryFallback;
-    Exception issue = null;
-    try {
-      tryFallback = !initialConnectionLatch.await(initialConnectionTimeoutMs, TimeUnit.MILLISECONDS);
-    } catch (Exception e) {
-      tryFallback = true;
-      issue = e;
-    }
-
-    if (tryFallback) {
-      boolean delegateChanged = recreateDelegate(true);
-      if (delegateChanged) {
-        if (issue != null) {
-          LOG.error("exception waiting to contact {}, using user-provided configs as fallback",
-              mdsClient.getLastAttemptedMarioUrl(), issue);
-        } else {
-          LOG.warn("unable to contact {} within timeout ({}), using user-provided configs as fallback",
-              mdsClient.getLastAttemptedMarioUrl(), initialConnectionTimeoutMs);
-        }
-      } else if (issue != null) {
-        //we got interrupted waiting, but apparently connection to mds was successful?
-        LOG.warn("exception waiting on MDS connection, yet connection succeeded?", issue);
-      }
-    }
   }
 
   @Override
@@ -185,7 +160,8 @@ public class LiKafkaInstrumentedConsumerImpl<K, V> implements DelegatingConsumer
             LOG.info("successfully connected to {}, no config overrides", mdsClient.getLastConnectedMarioUrl());
           }
           this.configOverrides = newOverrides;
-          recreateDelegate(false);
+          //honor the other creation in constructor if any
+          recreateDelegate(true);
         }
       } finally {
         initialConnectionLatch.countDown();


### PR DESCRIPTION
Remove waiting for connection to conductor during instrumented client creation to avoid blocking kafka clients initialization.